### PR TITLE
use allow list for git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,23 @@
-# ignore Apple's desktop store files
-**/.DS_Store
+# uses allow-list, so ignore everything
+*
 
-# ignore VS and Eclipse files
-.project
-.vscode/
-.settings/
+# allow github, workflows and templates
+!.github/**/*
+!.gitignore
+!.lycheeignore
 
-# ignore IntelliJ IDEA files
-.idea/
+# allow jekyll build files
+!404.html
+!_config.yml
+!_data/*.yaml
+!_includes/*.html
 
-# ignore working files
-/Gemfile
-/Gemfile.lock
-/favicon.ico
-_site/
-devsite.txt
+# draft version
+!draft/**/*.md
+!draft/assets/images/*.png
+
+# pages markdown
+!./*.md
+!assets/images/*
+!LICENSE.txt
 


### PR DESCRIPTION
**Summary**
For security reasons it is better to have an allow list in file `.gitignore` rather than a blocklist / denylist
This helps stop inadvertently including credentials in the repo

**Description for the changelog**
use allow list for git ignore

**Other info**


Thanks for submitting a pull request! Please make sure you follow our code of conduct
https://github.com/OWASP/www-project-developer-guide/blob/main/CODE_OF_CONDUCT.md
