### PR TITLE
add sections for background and fundamentals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,12 +18,12 @@
 # draft version
 !draft/
 !draft/title*.yaml
-!draft/**
+!draft/0*/
 !draft/**/*.md
 !draft/assets/images/*.png
 
 # pages markdown
 !./*.md
-!assets/images/*
+!assets/images/*.png
 !LICENSE.txt
 

--- a/_data/draft.yaml
+++ b/_data/draft.yaml
@@ -7,11 +7,17 @@ docs:
 - title: '2. Background'
   url: 02-background
 
-- title: '3. Abstract'
-  url: 03-abstract
+- title: '3. Introduction'
+  url: 03-introduction
 
-- title: '4. Introduction'
-  url: 04-introduction
+- title: '4. Foundations'
+  url: 04-foundations/toc
+
+- title: '4.1 Security fundamentals'
+  url: 04-foundations/01-foundations
+
+- title: '4.2 Secure Development Lifecycle (SDLC)'
+  url: 04-foundations/02-sdlc
 
 - title: '5. Security requirements'
   url: 05-security-requirements/toc
@@ -19,11 +25,14 @@ docs:
 - title: '5.1 Introduction'
   url: 05-security-requirements/01-security-requirements
 
-- title: '5.2 Threat modeling'
-  url: 05-security-requirements/02-threat-modeling
+- title: '5.2 Regulatory and statutory requirements'
+  url: 05-security-requirements/02-regulatory-statutory-requirements
 
-- title: '5.3 Regulatory and statutory requirements'
-  url: 05-security-requirements/03-regulatory-statutory-requirements
+- title: '5.3 Threat modeling'
+  url: 05-security-requirements/03-threat-modeling
+
+- title: '5.4 Remediation'
+  url: 05-security-requirements/04-remediation
 
 - title: '6. Secure design'
   url: 06-secure-design/toc

--- a/draft/00-toc.md
+++ b/draft/00-toc.md
@@ -18,14 +18,17 @@ _The draft version has the latest contributions to the Developer Guide, and so t
 
 2 **[Background](#background)**
 
-3 **[Abstract](#abstract)**
+3 **[Introduction](#introduction)**
 
-4 **[Introduction](#introduction)**
+4 **[Foundations](#foundations)**  
+4.1 [Security fundamentals](#security-fundamentals)  
+4.2 [Secure Development Lifecycle (SDLC)](#secure-development-lifecycle)  
 
 5 **[Security requirements](#security-requirements)**  
 5.1 [Introduction](#introduction-to-security-requirements)  
-5.2 [Threat modeling](#threat-modeling)  
-5.3 [Regulatory and statutory requirements](#regulatory-and-statutory-requirements)  
+5.2 [Regulatory and statutory requirements](#regulatory-and-statutory-requirements)  
+5.3 [Threat modeling](#threat-modeling)  
+5.4 [Remediation](#remediation)  
 
 6 **[Secure design](#secure-design)**  
 6.1 [Introduction](#introduction-to-secure-design)  

--- a/draft/02-background.md
+++ b/draft/02-background.md
@@ -13,11 +13,27 @@ order: 200
 {% include breadcrumb.html %}
 ### 2. Background
 
-The OWASP Development Guide is being rewritten by the OWASP community.
-and the content of this section has yet to be filled in.
+Welcome to the OWASP Development Guide.
 
-If you would like to contribute then follow the 
-[contributing guidelines](https://github.com/OWASP/www-project-developer-guide/blob/main/CONTRIBUTING.md)
-and submit your content for review.
+Along with the OWASP Top Ten, the Developer Guide is one of the original resources
+published soon after OWASP was formed in 2001.
+Version 1.0 of the Developer Guide was released in 2002
+and since then there have been various [releases][versions] culminating in version 2.0 in 2005.
+The guide has been revised extensively to bring it up to date since then and no longer has version numbers,
+but notionally it is version 4.0 as version 3.0 was never released.
+
+The purpose of this guide is to provide an introduction to security and a handy reference for application / system developers.
+Much of this guide is based on various OWASP sources:
+
+* [Top 10][top10]
+* [Cheat Sheet Series][cheat]
+* [Web Security Testing Guide][wstg]
+
+and for greater detail or wider context then follow the links to these resources.
+
+[cheat]: https://owasp.org/www-project-cheat-sheets/
+[top10]: https://owasp.org/www-project-top-ten/
+[versions]: https://github.com/OWASP/DevGuide/wiki#old-versions
+[wstg]: https://owasp.org/www-project-web-security-testing-guide/
 
 \newpage

--- a/draft/03-introduction.md
+++ b/draft/03-introduction.md
@@ -1,17 +1,17 @@
 ---
 
-title: Regulatory and Statutory Requirements
+title: Introduction
 layout: col-document
 tags: OWASP Developer Guide
 author:
 contributors:
 document: OWASP Developer Guide
-order: 503
+order: 300
 
 ---
 
 {% include breadcrumb.html %}
-### 5.3 Regulatory and Statutory Requirements
+### 3. Introduction
 
 The OWASP Development Guide is being rewritten by the OWASP community.
 and the content of this section has yet to be filled in.

--- a/draft/04-introduction/00-toc.md
+++ b/draft/04-introduction/00-toc.md
@@ -1,0 +1,25 @@
+---
+
+title: Foundations overview
+layout: col-document
+tags: OWASP Developer Guide
+author:
+contributors:
+document: OWASP Developer Guide
+order:
+
+---
+
+{% include breadcrumb.html %}
+## 4. Foundations
+
+### Overview
+This should be a brief overview / abstract of the section on foundations.
+Section 4.1 contains more detail and the further sections expand on that
+
+Sections:
+
+4.1 [Security fundamentals](#security-fundamentals)  
+4.2 [Secure Development Lifecycle (SDLC)](#secure-development-lifecycle)  
+
+\newpage

--- a/draft/04-introduction/01-foundations.md
+++ b/draft/04-introduction/01-foundations.md
@@ -1,0 +1,58 @@
+---
+
+title: Security Fundamentals
+layout: col-document
+tags: OWASP Developer Guide
+author:
+contributors:
+document: OWASP Developer Guide
+order: 401
+
+---
+
+{% include breadcrumb.html %}
+### 4. Security fundamentals
+
+Security is simply about controlling who can interact with your information, what they can do with it, and when they can interact with it.
+These characteristics of control are described through what is called the CIA triad.
+
+##  CIA
+CIA stands for Confidentiality, Integrity and Availability, and it is usually depicted as a triangle representing the strong bonds between its three tenets.
+This trio is considered the pillars of application security, with CIA described as a property of some data or of a process.
+Often CIA is extended with Authorization, Authentication and Auditing.
+
+### Confidentiality
+Confidentiality is the protection of data against unauthorized disclosure;
+it is about ensuring that only those with the correct authorization can access the data.
+Confidentiality applies to data at rest, and should also be considered for data in motion.
+Confidentiality is related to the broader concept of data privacy.
+
+### Integrity
+Integrity is about protecting data against unauthorized modification, or assuring data trustworthiness.
+The concept contains the notion of data integrity (data has not been changed accidentally or deliberately)
+and the notion of source integrity (data came from or was changed by a legitimate source).
+
+### Availability
+Availability is about ensuring the presence of information or resources.
+This concept relies not just on the availability of the data itself, for example by using replication of data,
+but also on the protection of the services that provide access to the data, for example by using load balancing.
+
+## AAA
+CIA is often extended with Authentication, Authorization and Auditing as these are closely linked to CIA concepts.
+CIA has such a strong dependency on Authentication and Authorization that the confidentiality of the data in question can't be assured without them.
+Auditing is added as it can provide the mechanism to ensure proof of any interaction with the system.
+
+### Authentication
+Authentication is about confirming the identity of the entity that wants to interact with a secure system.
+
+### Authorization
+Authorization is about specifying access rights to secure resources (data, services, files, applications, etc).
+These rights describe the privileges or access levels related to the resources in question. It is normally preceded by *Authentication*.
+
+### Auditing
+Auditing is about keeping track of implementation-level events, as well as domain-level events taking place in a system.
+This helps to provide non-repudiation, which means that changes or actions on the protected system are undeniable.
+Auditing can provide not only technical information about the running system, but also proof that particular actions have been performed.
+The typical questions that are answered by auditing are "*Who* did *What*? *When*? And potentially *How*?"
+
+\newpage

--- a/draft/04-introduction/02-sdlc.md
+++ b/draft/04-introduction/02-sdlc.md
@@ -1,17 +1,17 @@
 ---
 
-title: Abstract
+title: Secure Development Lifecycle
 layout: col-document
 tags: OWASP Developer Guide
 author:
 contributors:
 document: OWASP Developer Guide
-order: 300
+order: 402
 
 ---
 
 {% include breadcrumb.html %}
-### 3. Abstract
+### 5.3 Secure Development Lifecycle
 
 The OWASP Development Guide is being rewritten by the OWASP community.
 and the content of this section has yet to be filled in.

--- a/draft/04-introduction/info.md
+++ b/draft/04-introduction/info.md
@@ -1,0 +1,1 @@
+{% include navigation.html collection="draft" %}

--- a/draft/04-introduction/toc.md
+++ b/draft/04-introduction/toc.md
@@ -1,0 +1,23 @@
+---
+
+title: Table of Contents and Overview
+layout: col-document
+tags: OWASP Developer Guide
+author:
+contributors:
+document: OWASP Developer Guide
+order: 400
+
+---
+
+{% include breadcrumb.html %}
+## 4. Foundations
+
+### Overview
+This should be a brief overview / abstract of the section on foundations.
+Section 4.1 contains more detail and the further sections expand on that
+
+Sections:
+
+4.1 [Security fundamentals](01-foundations.md)  
+4.2 [Secure Development Lifecycle (SDLC)](02-sdlc.md)  

--- a/draft/05-security-requirements/02-regulatory-statutory-requirements.md
+++ b/draft/05-security-requirements/02-regulatory-statutory-requirements.md
@@ -1,6 +1,6 @@
 ---
 
-title: Threat modeling
+title: Regulatory and Statutory Requirements
 layout: col-document
 tags: OWASP Developer Guide
 author:
@@ -11,7 +11,7 @@ order: 502
 ---
 
 {% include breadcrumb.html %}
-### 5.2 Threat modeling
+### 5.2 Regulatory and Statutory Requirements
 
 The OWASP Development Guide is being rewritten by the OWASP community.
 and the content of this section has yet to be filled in.
@@ -19,7 +19,5 @@ and the content of this section has yet to be filled in.
 If you would like to contribute then follow the 
 [contributing guidelines](https://github.com/OWASP/www-project-developer-guide/blob/main/CONTRIBUTING.md)
 and submit your content for review.
-
-(hive off to threat modeling material on OWASP)
 
 \newpage

--- a/draft/05-security-requirements/03-threat-modeling.md
+++ b/draft/05-security-requirements/03-threat-modeling.md
@@ -1,17 +1,17 @@
 ---
 
-title: Introduction
+title: Threat modeling
 layout: col-document
 tags: OWASP Developer Guide
 author:
 contributors:
 document: OWASP Developer Guide
-order: 400
+order: 503
 
 ---
 
 {% include breadcrumb.html %}
-### 4. Introduction
+### 5.3 Threat modeling
 
 The OWASP Development Guide is being rewritten by the OWASP community.
 and the content of this section has yet to be filled in.
@@ -19,5 +19,7 @@ and the content of this section has yet to be filled in.
 If you would like to contribute then follow the 
 [contributing guidelines](https://github.com/OWASP/www-project-developer-guide/blob/main/CONTRIBUTING.md)
 and submit your content for review.
+
+(hive off to threat modeling material on OWASP)
 
 \newpage

--- a/draft/05-security-requirements/04-remediation.md
+++ b/draft/05-security-requirements/04-remediation.md
@@ -1,0 +1,48 @@
+---
+
+title: Remediation
+layout: col-document
+tags: OWASP Developer Guide
+author:
+contributors:
+document: OWASP Developer Guide
+order: 504
+
+---
+
+{% include breadcrumb.html %}
+### 5.4 Remediation
+
+Risk management is the identification, assessment, and prioritization of risks to the application or system.
+The objective of risk management is to ensure that uncertainty does not deflect the endeavor from the business goals,
+and remediation is the strategy chosen in response to identifying this risk.
+
+Risk management can be split in two parts. First, determine which risks exists and then secondly handling those risks in a way that is best for the business;
+risk management should always be business driven.
+
+There are four common ways to handling risk:
+
+1. Acceptance: the business is aware of the risk but has decided that no action needs to be taken; the risk is deemed acceptable
+
+2. Mitigation: the risk is considered serious enough to require implementation of security controls to remove the risk
+
+3. Transferring: the risk is considered serious but can be transferred to another party
+
+4. Elimination: the risk can be avoided or removed completely, often by removing the object with which the risk is associated
+
+Examples:
+
+1. Acceptance: sometimes risks are so low in priority or bearable that it is not worth mitigating,
+    an example might be where the version of software is revealed but this is acceptable (or even desirable)
+
+2. Mitigation: there are many examples of where risks are mitigated;
+    for example input sanitization or output encoding may be used for information supplied by an untrusted source,
+    or the use of encrypted communication channels for transferring sensitive information
+
+3. Transferring: a common example of transferring risk is the use of third party insurance in response to the risk of RansomWare.
+    Insurance premiums are paid but losses to the business are covered by the insurance
+
+4. Elimination: an example may be that an application implements legacy functionality that is no longer used,
+    if there is a risk of it being exploited then the risk can be eliminated by removing this legacy functionality
+
+\newpage

--- a/draft/05-security-requirements/toc.md
+++ b/draft/05-security-requirements/toc.md
@@ -20,5 +20,6 @@ The Introduction contains more detail and the further sections expand on that
 Sections:
 
 5.1 [Introduction](01-security-requirements.md)  
-5.2 [Threat modeling](02-threat-modeling.md)  
-5.3 [Regulatory and statutory requirements](03-regulatory-statutory-requirements.md)
+5.2 [Regulatory and statutory requirements](03-regulatory-statutory-requirements.md)  
+5.3 [Threat modeling](02-threat-modeling.md)  
+5.4 [Remediation](04-remediation.md)  

--- a/draft/toc.md
+++ b/draft/toc.md
@@ -18,14 +18,17 @@ _The draft version has the latest contributions to the Developer Guide, and so t
 
 2 **[Background](02-background.md)**
 
-3 **[Abstract](03-abstract.md)**
+3 **[Introduction](03-introduction.md)**
 
-4 **[Introduction](04-introduction.md)**
+4 **[Foundations](04-foundations/toc.md)**
+4.1 [Security fundamentals](04-foundations/01-foundations.md)  
+4.2 [Secure Development Lifecycle (SDLC)](02-sdlc.md)  
 
 5 **[Security requirements](05-security-requirements/toc.md)**  
 5.1 [Introduction](05-security-requirements/01-security-requirements.md)  
-5.2 [Threat modeling](05-security-requirements/02-threat-modeling.md)  
-5.3 [Regulatory and statutory requirements](05-security-requirements/03-regulatory-statutory-requirements.md)  
+5.2 [Regulatory and statutory requirements](05-security-requirements/02-regulatory-statutory-requirements.md)  
+5.3 [Threat modeling](05-security-requirements/03-threat-modeling.md)  
+5.2 [Remediation](05-security-requirements/04-remediation.md)  
 
 6 **[Secure design](06-secure-design/toc.md)**  
 6.1 [Introduction](06-secure-design/01-secure-design.md)  

--- a/index.md
+++ b/index.md
@@ -20,11 +20,10 @@ pitch: The Developer Guide allows businesses, developers, designers
 {% endif %}
 
 Along with the OWASP Top Ten, the Developer Guide is one of the original resources
-published by OWASP soon after it was created in 2001.
+published soon after OWASP was formed in 2001.
 
-Version 1.0 of the Developer Guide was provided in 2002
-and since then there have been various [releases][versions],
-the latest being version 2.0 in 2005.
+Version 1.0 of the Developer Guide was released in 2002
+and since then there have been various [releases][versions], the latest being version 2.0 in 2005.
 There is a [draft version](draft) available that is based on an unreleased version (3.0) from 2015.
 This is very much work in progress and is subject to large scale and frequent changes.
 


### PR DESCRIPTION
**Summary**
This rearranges the chapters for '04 Fundamentals' and '05 Security Requirements'
Adds sections :
* 02-background
* 04-introduction/01-foundations
* 05-security-requirements/04-remediation

**Description for the changelog**
add sections for background and fundamentals

**Other info**
Closes #14 

