### PR TITLE
Automation: corrections to diagrams for pandoc

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,7 @@ jobs:
           args: >-
             --from=markdown
             --output=publish/OWASP_Developer_Guide.draft.epub
-            --resource-path=draft
+            --resource-path="draft/assets:draft"
             draft/title.pdf.yaml
             draft.markdown
 
@@ -78,7 +78,7 @@ jobs:
           args: >-
             --from=markdown
             --output=publish/OWASP_Developer_Guide.draft.epub
-            --resource-path=draft
+            --resource-path="draft/assets:draft"
             draft/title.yaml
             draft.markdown
 

--- a/contributing.md
+++ b/contributing.md
@@ -80,8 +80,8 @@ To run these checks locally before pushing a commit, run these commands from the
 3. Spell checker: `pyspelling --config .spellcheck.yaml`
 4. PDF and ePub:
     1. `tail --lines=+14 -q draft/*0*.md draft/*0**/*0*.md > draft.markdown`
-    2. `pandoc --from=markdown --output=draft.pdf --resource-path=draft draft/title.pdf.yaml draft.markdown`
-    3. `pandoc --from=markdown --output=draft.epub --resource-path=draft draft/title.yaml draft.markdown`
+    2. `pandoc --from=markdown --output=draft.pdf --resource-path="draft/assets:draft" draft/title.pdf.yaml draft.markdown`
+    3. `pandoc --from=markdown --output=draft.epub --resource-path="draft/assets:draft" draft/title.yaml draft.markdown`
 
 Follow instructions to install the command line [lychee][lychee-install] and [pandoc][pandoc-install].
 

--- a/contributing.md
+++ b/contributing.md
@@ -80,8 +80,8 @@ To run these checks locally before pushing a commit, run these commands from the
 3. Spell checker: `pyspelling --config .spellcheck.yaml`
 4. PDF and ePub:
     1. `tail --lines=+14 -q draft/*0*.md draft/*0**/*0*.md > draft.markdown`
-    2. `pandoc --from=markdown --output=draft.pdf --resource-path="draft/assets:draft" draft/title.pdf.yaml draft.markdown`
-    3. `pandoc --from=markdown --output=draft.epub --resource-path="draft/assets:draft" draft/title.yaml draft.markdown`
+    2. `pandoc -f markdown -o draft.pdf --resource-path="draft/assets:draft" draft/title.pdf.yaml draft.markdown`
+    3. `pandoc -f markdown -o draft.epub --resource-path="draft/assets:draft" draft/title.yaml draft.markdown`
 
 Follow instructions to install the command line [lychee][lychee-install] and [pandoc][pandoc-install].
 

--- a/draft/00-toc.md
+++ b/draft/00-toc.md
@@ -12,9 +12,7 @@ permalink: /draft/
 
 {% include breadcrumb.html %}
 
-## ![SDLC Diagram](../assets/images/dg_logo.png){ height="220px" }
-
-\newpage
+## ![Developer Guide](../assets/images/dg_logo.png){ height=220px }
 
 ## OWASP Developer Guide (draft)
 

--- a/draft/04-foundations/02-secure-development.md
+++ b/draft/04-foundations/02-secure-development.md
@@ -25,6 +25,8 @@ Theses phases are revisited in a cyclic manner throughout the lifetime of the ap
 A generic Software Development LifeCycle (SDLC) is shown below, and in practice there may be more or less phases
 according to the processes adopted by the business.
 
+![SDLC Diagram](../assets/images/sdlc_diag.png "typical SDLC diagram"){: height="220px" }
+
 With the increasing number and sophistication of exploits against almost every application or business system,
 most companies have adopted a secure Software Development LifeCycle (SDLC).
 The secure SDLC should never be a separate lifecycle,
@@ -41,8 +43,6 @@ and to provide the SDLC with automated security testing.
 Examples of how DevSecOps is 'building security in' is the provision of
 Interactive, Static and Dynamic Application Security Testing (IAST, SAST & DAST)
 and implementing supply chain security, and there are many other security activities that can be applied.
-
-![SDLC Diagram](../assets/images/sdlc_diag.png "typical SDLC diagram"){ :height="25px" }
 
 #### Secure development lifecycle
 

--- a/draft/toc.md
+++ b/draft/toc.md
@@ -12,7 +12,7 @@ permalink: /draft/
 
 {% include breadcrumb.html %}
 
-![SDLC Diagram](../assets/images/dg_logo.png "OWASP Developer Guide"){ :height="220px" }
+![Developer Guide](../assets/images/dg_logo.png "OWASP Developer Guide"){: height="220px" }
 
 ## OWASP Developer Guide (draft)
 


### PR DESCRIPTION
**Summary** :  
The SDLC diagram is not found by pandoc for the PDF and ePub outputs
It would be good for this to be corrected and also for the diagram style to be applied

**Description for the changelog** :  
corrections to diagrams for pandoc

**Other info** :  
