### PR TITLE
update link for ThreatSpec tool

### DIFF
--- a/draft/05-security-requirements/02-threat-modeling.md
+++ b/draft/05-security-requirements/02-threat-modeling.md
@@ -231,7 +231,7 @@ then that is a perfectly good choice.
 * OWASP [Threat Dragon][TD] threat modeling tool using dataflow diagrams
 * [Threagile](https://threagile.io), an open source project that provides for Agile threat modeling
 * Microsoft [Threat Modeling Tool][TMT], a widely used tool throughout the security community and free to download
-* [threatspec](https://threatspec.org/), an open source tool based on comments inline with code
+* [threatspec](https://github.com/threatspec/threatspec), an open source tool based on comments inline with code
 * Mitre's Common Attack Pattern Enumeration and Classification ([CAPEC][capec])
 * NIST [Common Vulnerability Scoring System Calculator][nist-cvss]
 


### PR DESCRIPTION
**Summary** :  
There is a broken link for the ThreatSpec tool, this fixes that

**Description for the changelog** :  
update link for ThreatSpec tool

**Other info** :  

