### PR TITLE
remove reference to flowcrypt

### DIFF
--- a/security.md
+++ b/security.md
@@ -7,10 +7,7 @@ in the markdown or subvert the document creation process.
 If you find anything suspicious in either the markdown or pipeline scripts
 then let us know ASAP and we will fix it as a priority.
 
-Ideally open a [security advisory][advisory] and this will be provided
-only to the project's admins in strict confidence.
-
-Alternatively send an encrypted email to [Jon Gadsden][mail] to start the secure disclosure process.
+Open a [security advisory][advisory] and this will be provided
+only to the project's admins and in strict confidence.
 
 [advisory]: https://github.com/OWASP/www-project-developer-guide/security/advisories/new
-[mail]: https://flowcrypt.com/me/jongadsden


### PR DESCRIPTION
**Summary** :  
Flowcrypt link no longer works, and was of dubious benefit anyway, so removing it

**Description for the changelog** :  
remove reference to flowcrypt

**Other info** :  

