### PR TITLE
Add new section on security champions

### DIFF
--- a/_data/draft.yaml
+++ b/_data/draft.yaml
@@ -25,6 +25,9 @@ docs:
 - title: '4.4 Principles of cryptography'
   url: 04-foundations/04-crypto-principles
 
+- title: '4.6 Security champions'
+  url: 04-foundations/06-security-champions
+
 - title: '5. Security requirements'
   url: 05-security-requirements/toc
 

--- a/draft/00-toc.md
+++ b/draft/00-toc.md
@@ -31,6 +31,7 @@ and so the content is expected to frequently change._
 4.3 [Principles of security](#principles-of-security)  
 4.4 [Principles of cryptography](#principles-of-cryptography)  
 4.5 [Top Ten Web Application Security Risks](#top-ten-web-application-security-risks)  
+4.6 [Security champions](#security-champions)
 
 5 **[Security requirements](#security-requirements)**  
 5.1 [Introduction](#introduction-to-security-requirements)  

--- a/draft/04-foundations/00-toc.md
+++ b/draft/04-foundations/00-toc.md
@@ -26,5 +26,6 @@ Sections:
 4.3 [Principles of security](#principles-of-security)  
 4.4 [Principles of cryptography](#principles-of-cryptography)  
 4.5 [Top Ten Web Application Security Risks](#top-ten-web-application-security-risks)  
+4.6 [Security champions](#security-champions)
 
 \newpage

--- a/draft/04-foundations/06-security-champions.md
+++ b/draft/04-foundations/06-security-champions.md
@@ -13,21 +13,84 @@ order: 405
 
 ### 4.6 Security champions
 
-![Developer Guide](../assets/images/dg_wip.png "OWASP Developer Guide"){: height="220px" }
+A Security Champion program is a commonly used way of helping development teams successfully run a development lifecycle
+that is secure, and this is achieved by selecting members of the teams to become Security Champions.
+The role of Security Champion is described by the OWASP Software Assurance Maturity Model [(SAMM)][sammoc]
+Organization and Culture stream within the Governance business function of the Education & Guidance practice.
 
-The OWASP Development Guide is being rewritten by the OWASP community,
-and the content has yet to be filled in for section 'Top Ten Web Application Security Risks'.
+#### Overview
 
-If you would like to contribute then follow the [contributing guidelines][contribute]
-and submit your content for review.
+Referring to the OWASP [Security Culture project][scculture], it can be hard to introduce security across development teams
+using the application security team alone. Information Security people do not scale across teams of developers.
+A good way to scale security and distribute security across development teams is by using Security Champions
+and providing a Security Champions program to encourage this community within the organization.
+
+Security champions are usually individuals within each development team that show special interest in application security.
+The security champion provides a knowledgeable point of contact between the application security team and development,
+and in addition they can ensure that the development lifecycle has security built in.
+Often the security champion carries on with their original role within the development team, in addition to their new role,
+and so a Security Champions program is important for providing support and training and avoiding burn-out.
+
+#### Security champion role
+
+Security Champions are active members of a development team that act as the "voice" of security within their team.
+Security Champions also provide visibility of their team's security activities to the application security team,
+and are seen as the first point of contact between developers and a central security team.
+
+There is no universally defined role for a security champion, but the [Security Culture project][scculture]
+provides various suggestions:
+
+* Evangelise security: promoting security best practice in their team,
+    imparting security knowledge and helping to uplift security awareness in their team
+* Contribute to security standards: provide input into organisational security standards and procedures
+* Help run activities: promote activities such as Capture the Flag events or secure coding training
+* Oversee threat modelling: threat modelling consists of a security review on a product in the design phase
+* Oversee secure code reviews: raise issues of risk in the code base that arise from peer group code reviews
+* Use security testing tools: provide support to their team for the use of security testing tools
+
+An important point to keep in mind is that security champions should come forward because they are interested in security,
+rather than assigned or chosen out of expediency.
+It is a role that requires a passion and interest in application security, we are hard to find but we certainly do exist.
+
+#### Security champions program
+
+It can be tough being a security champion: usually they are still expected to do their 'day job' but in addition
+they are expected to be knowledgeable on security matters and to take extra training.
+Relying on good will and cheerful interest will only go so far, and a Security Champions program should be put in place
+to identify, nurture, support and train the security champions.
+
+The OWASP [Security Champions Guide][scguide] identifies ten key principles for a successful Security Champions program:
+
+* Be passionate about security - identify the members of the teams that show interest in security
+* Start with a clear vision for your program - be practical but ambitious, after if it works then it will work well
+* Secure management support - as always, going it alone without management support is never going to work
+* Nominate a dedicated captain - the program will take organisation and maintaining, so find someone willing to do that
+* Trust your champions - they are usually highly motivated when it comes to the security of their own applications
+* Create a community - it can be lonely, so provide a support network
+* Promote knowledge sharing - if the community is in place, then encourage discussions and meet-ups
+* Reward responsibility - they are putting extra work, so appreciate them
+* Invest in your champions - the knowledge gained through extra training will pay for itself many times over
+* Anticipate personnel changes - the security champion may move on, be alert to this and plan for it
+
+A successful security champions program will increase the security of the applications / systems, allay developer's fears,
+increase the effectiveness of the application security team and improve the security posture of the organization as a whole.
+
+#### Further reading
+
+* [Security Champions Playbook][scplaybook]
+* OWASP [Security Champions Guide][scguide]
+* OWASP [Security Culture project][scculture]
 
 ----
 
 The OWASP Developer Guide is a community effort; if there is something that needs changing
 then [submit an issue][issue0406] or a [pull request][pr] .
 
-[contribute]: https://github.com/OWASP/www-project-developer-guide/blob/main/contributing.md
 [issue0406]: https://github.com/OWASP/www-project-developer-guide/issues/new?labels=enhancement&template=request.md&title=Update:%2004-foundations/06-security-champions
 [pr]: https://github.com/OWASP/www-project-developer-guide/pulls
+[sammoc]: https://owaspsamm.org/model/governance/education-and-guidance/stream-b/
+[scguide]: https://owasp.org/www-project-security-champions-guidebook/
+[scplaybook]: https://github.com/c0rdis/security-champions-playbook
+[scculture]: https://owasp.org/www-project-security-culture/stable/4-Security_Champions/
 
 \newpage

--- a/draft/04-foundations/06-security-champions.md
+++ b/draft/04-foundations/06-security-champions.md
@@ -14,16 +14,16 @@ order: 405
 ### 4.6 Security champions
 
 A Security Champion program is a commonly used way of helping development teams successfully run a development lifecycle
-that is secure, and this is achieved by selecting members of the teams to become Security Champions.
+that is secure, and this is achieved by selecting members of teams to become Security Champions.
 The role of Security Champion is described by the OWASP Software Assurance Maturity Model [(SAMM)][sammoc]
 Organization and Culture stream within the Governance business function of the Education & Guidance practice.
 
 #### Overview
 
 Referring to the OWASP [Security Culture project][scculture], it can be hard to introduce security across development teams
-using the application security team alone. Information Security people do not scale across teams of developers.
-A good way to scale security and distribute security across development teams is by using Security Champions
-and providing a Security Champions program to encourage this community within the organization.
+using the application security team alone. Information security people do not scale across teams of developers.
+A good way to scale security and distribute security across development teams is by creating a security champion role
+and providing a Security Champions program to encourage a community spirit within the organization.
 
 Security champions are usually individuals within each development team that show special interest in application security.
 The security champion provides a knowledgeable point of contact between the application security team and development,
@@ -33,8 +33,8 @@ and so a Security Champions program is important for providing support and train
 
 #### Security champion role
 
-Security Champions are active members of a development team that act as the "voice" of security within their team.
-Security Champions also provide visibility of their team's security activities to the application security team,
+Security champions are active members of a development team that act as the "voice" of security within their team.
+Security champions also provide visibility of their team's security activities to the application security team,
 and are seen as the first point of contact between developers and a central security team.
 
 There is no universally defined role for a security champion, but the [Security Culture project][scculture]
@@ -48,9 +48,10 @@ provides various suggestions:
 * Oversee secure code reviews: raise issues of risk in the code base that arise from peer group code reviews
 * Use security testing tools: provide support to their team for the use of security testing tools
 
-An important point to keep in mind is that security champions should come forward because they are interested in security,
-rather than assigned or chosen out of expediency.
-It is a role that requires a passion and interest in application security, we are hard to find but we certainly do exist.
+The security champion role requires a passion and interest in application security,
+and so arbitrarily assigning this role is unlikely to work in practice.
+A better strategy is to provide a security champions program, so that developers who are interested can come forward;
+in effect they should self-select.
 
 #### Security champions program
 

--- a/draft/04-foundations/06-security-champions.md
+++ b/draft/04-foundations/06-security-champions.md
@@ -1,0 +1,33 @@
+---
+
+title: Security Champions
+layout: col-document
+tags: OWASP Developer Guide
+contributors:
+document: OWASP Developer Guide
+order: 405
+
+---
+
+{% include breadcrumb.html %}
+
+### 4.6 Security champions
+
+![Developer Guide](../assets/images/dg_wip.png "OWASP Developer Guide"){: height="220px" }
+
+The OWASP Development Guide is being rewritten by the OWASP community,
+and the content has yet to be filled in for section 'Top Ten Web Application Security Risks'.
+
+If you would like to contribute then follow the [contributing guidelines][contribute]
+and submit your content for review.
+
+----
+
+The OWASP Developer Guide is a community effort; if there is something that needs changing
+then [submit an issue][issue0406] or a [pull request][pr] .
+
+[contribute]: https://github.com/OWASP/www-project-developer-guide/blob/main/contributing.md
+[issue0406]: https://github.com/OWASP/www-project-developer-guide/issues/new?labels=enhancement&template=request.md&title=Update:%2004-foundations/06-security-champions
+[pr]: https://github.com/OWASP/www-project-developer-guide/pulls
+
+\newpage

--- a/draft/04-foundations/toc.md
+++ b/draft/04-foundations/toc.md
@@ -26,3 +26,4 @@ Sections:
 4.3 [Principles of security](03-security-principles.md)  
 4.4 [Principles of cryptography](04-crypto-principles.md)  
 4.5 [Top Ten Web Application Security Risks](05-top-ten.md)  
+4.6 [Security champions](06-security-champions.md)

--- a/draft/11-checklist/01-define-security-requirements.md
+++ b/draft/11-checklist/01-define-security-requirements.md
@@ -55,11 +55,11 @@ for more context from the 'OWASP Top 10 Proactive Controls' project.
 ----
 
 The OWASP Developer Guide is a community effort; if there is something that needs changing
-then [submit an issue][issue2002] or a [pull request][pr].
+then [submit an issue][issue2001] or a [pull request][pr].
 
 [asvs]: https://owasp.org/www-project-application-security-verification-standard/
 [control1]: https://owasp.org/www-project-proactive-controls/v3/en/c1-security-requirements.html
-[issue2002]: https://github.com/OWASP/www-project-developer-guide/issues/new?labels=enhancement&template=request.md&title=Update:%2020-proactive-control-checklist/02-define-security-requirements
+[issue2001]: https://github.com/OWASP/www-project-developer-guide/issues/new?labels=enhancement&template=request.md&title=Update:%2011-checklist/01-define-security-requirements
 [mas]: https://mas.owasp.org/
 [pr]: https://github.com/OWASP/www-project-developer-guide/pulls
 [proactive10]: https://owasp.org/www-project-proactive-controls/

--- a/draft/11-checklist/02-frameworks-libraries.md
+++ b/draft/11-checklist/02-frameworks-libraries.md
@@ -42,11 +42,11 @@ for more context from the 'OWASP Top 10 Proactive Controls' project.
 ----
 
 The OWASP Developer Guide is a community effort; if there is something that needs changing
-then [submit an issue][issue2003] or a [pull request][pr].
+then [submit an issue][issue2002] or a [pull request][pr].
 
 [control2]: https://owasp.org/www-project-proactive-controls/v3/en/c2-leverage-security-frameworks-libraries.html
 [dependency]: https://owasp.org/www-project-dependency-check/
-[issue2003]: https://github.com/OWASP/www-project-developer-guide/issues/new?labels=enhancement&template=request.md&title=Update:%2020-proactive-control-checklist/03-frameworks-libraries
+[issue2002]: https://github.com/OWASP/www-project-developer-guide/issues/new?labels=enhancement&template=request.md&title=Update:%2011-checklist/02-frameworks-libraries
 [pr]: https://github.com/OWASP/www-project-developer-guide/pulls
 [proactive10]: https://owasp.org/www-project-proactive-controls/
 

--- a/draft/11-checklist/03-secure-database-access.md
+++ b/draft/11-checklist/03-secure-database-access.md
@@ -52,11 +52,11 @@ for more context from the 'OWASP Top 10 Proactive Controls' project.
 ----
 
 The OWASP Developer Guide is a community effort; if there is something that needs changing
-then [submit an issue][issue2004] or a [pull request][pr].
+then [submit an issue][issue2003] or a [pull request][pr].
 
 [control3]: https://owasp.org/www-project-proactive-controls/v3/en/c3-secure-database.html
 [dbsec]: https://cheatsheetseries.owasp.org/cheatsheets/Database_Security_Cheat_Sheet.html
-[issue2004]: https://github.com/OWASP/www-project-developer-guide/issues/new?labels=enhancement&template=request.md&title=Update:%2020-proactive-control-checklist/04-secure-database-access
+[issue2003]: https://github.com/OWASP/www-project-developer-guide/issues/new?labels=enhancement&template=request.md&title=Update:%2011-checklist/03-secure-database-access
 [pr]: https://github.com/OWASP/www-project-developer-guide/pulls
 [proactive10]: https://owasp.org/www-project-proactive-controls/
 [query]: https://cheatsheetseries.owasp.org/cheatsheets/Query_Parameterization_Cheat_Sheet.html

--- a/draft/11-checklist/04-encode-escape-data.md
+++ b/draft/11-checklist/04-encode-escape-data.md
@@ -49,12 +49,12 @@ The specific methods vary depending on the way the output data is used, such as 
 ----
 
 The OWASP Developer Guide is a community effort; if there is something that needs changing
-then [submit an issue][issue2005] or a [pull request][pr].
+then [submit an issue][issue2004] or a [pull request][pr].
 
 [control4]: https://owasp.org/www-project-proactive-controls/v3/en/c4-encode-escape-data.html
 [encoder]: https://www.owasp.org/index.php/OWASP_Java_Encoder_Project
 [ipcs]: https://cheatsheetseries.owasp.org/cheatsheets/Injection_Prevention_Cheat_Sheet.html
-[issue2005]: https://github.com/OWASP/www-project-developer-guide/issues/new?labels=enhancement&template=request.md&title=Update:%2020-proactive-control-checklist/05-encode-escape-data
+[issue2004]: https://github.com/OWASP/www-project-developer-guide/issues/new?labels=enhancement&template=request.md&title=Update:%2011-checklist/04-encode-escape-data
 [pr]: https://github.com/OWASP/www-project-developer-guide/pulls
 [proactive10]: https://owasp.org/www-project-proactive-controls/
 

--- a/draft/11-checklist/05-validate-inputs.md
+++ b/draft/11-checklist/05-validate-inputs.md
@@ -62,11 +62,11 @@ Without input validation the software application/system will continue to be vul
 ----
 
 The OWASP Developer Guide is a community effort; if there is something that needs changing
-then [submit an issue][issue2006] or a [pull request][pr].
+then [submit an issue][issue2005] or a [pull request][pr].
 
 [control5]: https://owasp.org/www-project-proactive-controls/v3/en/c5-validate-inputs
 [ivcs]: https://cheatsheetseries.owasp.org/cheatsheets/Input_Validation_Cheat_Sheet.html
-[issue2006]: https://github.com/OWASP/www-project-developer-guide/issues/new?labels=enhancement&template=request.md&title=Update:%2020-proactive-control-checklist/06-validate-inputs
+[issue2005]: https://github.com/OWASP/www-project-developer-guide/issues/new?labels=enhancement&template=request.md&title=Update:%2011-checklist/05-validate-inputs
 [pr]: https://github.com/OWASP/www-project-developer-guide/pulls
 [proactive10]: https://owasp.org/www-project-proactive-controls/
 [sanitizer]: https://www.owasp.org/index.php/OWASP_Java_HTML_Sanitizer

--- a/draft/11-checklist/06-digital-identity.md
+++ b/draft/11-checklist/06-digital-identity.md
@@ -98,14 +98,14 @@ for more context from the 'OWASP Top 10 Proactive Controls' project.
 ----
 
 The OWASP Developer Guide is a community effort; if there is something that needs changing
-then [submit an issue][issue2007] or a [pull request][pr].
+then [submit an issue][issue2006] or a [pull request][pr].
 
 [control6]: https://owasp.org/www-project-proactive-controls/v3/en/c6-digital-identity
 [csauth]: https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html
 [cspass]: https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html
 [csforgot]: https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html
 [cssession]: https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html
-[issue2007]: https://github.com/OWASP/www-project-developer-guide/issues/new?labels=enhancement&template=request.md&title=Update:%2020-proactive-control-checklist/07-digital-identity
+[issue2006]: https://github.com/OWASP/www-project-developer-guide/issues/new?labels=enhancement&template=request.md&title=Update:%2011-checklist/06-digital-identity
 [pr]: https://github.com/OWASP/www-project-developer-guide/pulls
 [proactive10]: https://owasp.org/www-project-proactive-controls/
 

--- a/draft/11-checklist/07-access-controls.md
+++ b/draft/11-checklist/07-access-controls.md
@@ -49,11 +49,11 @@ for more context from the 'OWASP Top 10 Proactive Controls' project.
 ----
 
 The OWASP Developer Guide is a community effort; if there is something that needs changing
-then [submit an issue][issue2008] or a [pull request][pr].
+then [submit an issue][issue2007] or a [pull request][pr].
 
 [control7]: https://owasp.org/www-project-proactive-controls/v3/en/c7-enforce-access-controls
 [csaz]: https://cheatsheetseries.owasp.org/cheatsheets/Authorization_Cheat_Sheet.html
-[issue2008]: https://github.com/OWASP/www-project-developer-guide/issues/new?labels=enhancement&template=request.md&title=Update:%2020-proactive-control-checklist/08-access-controls
+[issue2007]: https://github.com/OWASP/www-project-developer-guide/issues/new?labels=enhancement&template=request.md&title=Update:%2011-checklist/07-access-controls
 [pr]: https://github.com/OWASP/www-project-developer-guide/pulls
 [proactive10]: https://owasp.org/www-project-proactive-controls/
 

--- a/draft/11-checklist/08-protect-data.md
+++ b/draft/11-checklist/08-protect-data.md
@@ -70,12 +70,12 @@ for more context from the 'OWASP Top 10 Proactive Controls' project.
 ----
 
 The OWASP Developer Guide is a community effort; if there is something that needs changing
-then [submit an issue][issue2009] or a [pull request][pr].
+then [submit an issue][issue2008] or a [pull request][pr].
 
 [control8]: https://owasp.org/www-project-proactive-controls/v3/en/c8-protect-data-everywhere
 [cscs]: https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html
 [cssm]: https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html
-[issue2009]: https://github.com/OWASP/www-project-developer-guide/issues/new?labels=enhancement&template=request.md&title=Update:%2020-proactive-control-checklist/09-protect-data
+[issue2008]: https://github.com/OWASP/www-project-developer-guide/issues/new?labels=enhancement&template=request.md&title=Update:%2011-checklist/08-protect-data
 [pr]: https://github.com/OWASP/www-project-developer-guide/pulls
 [proactive10]: https://owasp.org/www-project-proactive-controls/
 

--- a/draft/11-checklist/09-logging-monitoring.md
+++ b/draft/11-checklist/09-logging-monitoring.md
@@ -51,12 +51,12 @@ for more context from the 'OWASP Top 10 Proactive Controls' project.
 ----
 
 The OWASP Developer Guide is a community effort; if there is something that needs changing
-then [submit an issue][issue2010] or a [pull request][pr].
+then [submit an issue][issue2009] or a [pull request][pr].
 
 [control9]: https://owasp.org/www-project-proactive-controls/v3/en/c9-security-logging.html
 [cslogging]: https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html
 [csvocabulary]: https://cheatsheetseries.owasp.org/cheatsheets/Logging_Vocabulary_Cheat_Sheet.html
-[issue2010]: https://github.com/OWASP/www-project-developer-guide/issues/new?labels=enhancement&template=request.md&title=Update:%2020-proactive-control-checklist/10-logging-monitoring
+[issue2009]: https://github.com/OWASP/www-project-developer-guide/issues/new?labels=enhancement&template=request.md&title=Update:%2011-checklist/09-logging-monitoring
 [pr]: https://github.com/OWASP/www-project-developer-guide/pulls
 [proactive10]: https://owasp.org/www-project-proactive-controls/
 

--- a/draft/11-checklist/10-handle-errors-exceptions.md
+++ b/draft/11-checklist/10-handle-errors-exceptions.md
@@ -45,11 +45,11 @@ for more context from the 'OWASP Top 10 Proactive Controls' project.
 ----
 
 The OWASP Developer Guide is a community effort; if there is something that needs changing
-then [submit an issue][issue2011] or a [pull request][pr].
+then [submit an issue][issue2010] or a [pull request][pr].
 
 [control10]: https://owasp.org/www-project-proactive-controls/v3/en/c10-errors-exceptions.html
 [handle]: https://owasp.org/www-community/Improper_Error_Handling
-[issue2011]: https://github.com/OWASP/www-project-developer-guide/issues/new?labels=enhancement&template=request.md&title=Update:%2020-proactive-control-checklist/11-handle-errors-exceptions
+[issue2010]: https://github.com/OWASP/www-project-developer-guide/issues/new?labels=enhancement&template=request.md&title=Update:%2011-checklist/10-handle-errors-exceptions
 [pr]: https://github.com/OWASP/www-project-developer-guide/pulls
 [proactive10]: https://owasp.org/www-project-proactive-controls/
 [review]: https://owasp.org/www-project-code-review-guide/

--- a/draft/toc.md
+++ b/draft/toc.md
@@ -31,6 +31,7 @@ and so the content is expected to frequently change._
 4.3 [Principles of security](04-foundations/03-security-principles.md)  
 4.4 [Principles of cryptography](04-foundations/04-crypto-principles.md)  
 4.5 [Top Ten Web Application Security Risks](04-foundations/05-top-ten.md)  
+4.6 [Security champions](04-foundations/06-security-champions.md)
 
 5 **[Security requirements](05-security-requirements/toc.md)**  
 5.1 [Introduction](05-security-requirements/01-security-requirements.md)  


### PR DESCRIPTION
**Summary** :  
Add new section on Security Champions `04-Foundations / 06-security-champions` on how to implement a security champions program within an organization

**Description for the changelog** :  
add new section on security champions

**Other info** :  
closes #64 
