### PR TITLE
Add pages to correspond with Wayfinder

### DIFF
--- a/_data/draft.yaml
+++ b/_data/draft.yaml
@@ -48,37 +48,37 @@ docs:
 
 - title: '5.1 Documentation'
   url: 07-implementation/01-documentation/toc
-  
+
 - title: '5.2 Dependencies'
   url: 07-implementation/02-dependencies/toc
-  
+
 - title: '5.3 Secure Libraries'
   url: 07-implementation/03-secure-libraries/toc
-  
-- title: '5.4 Implementation Do's and Dont's'
+
+- title: '5.4 Implementation Do''s and Dont''s'
   url: 07-implementation/04-dos-donts/toc
-  
+
 - title: '5.4.1 Container security'
   url: 07-implementation/04-dos-donts/01-container-security
-  
+
 - title: '5.4.2 Secure coding'
   url: 07-implementation/04-dos-donts/02-secure-coding
-  
+
 - title: '5.4.3 Cryptographic practices'
   url: 07-implementation/04-dos-donts/03-cryptographic-practices
-  
+
 - title: '5.4.4 Application spoofing'
   url: 07-implementation/04-dos-donts/04-application-spoofing
-  
+
 - title: '5.4.5 Content Security Policy (CSP)'
   url: 07-implementation/04-dos-donts/05-content-security-policy
-  
+
 - title: '5.4.6 Exception and error handling'
   url: 07-implementation/04-dos-donts/06-exception-error-handling
-  
+
 - title: '5.4.7 File management'
   url: 07-implementation/04-dos-donts/07-file-management
-  
+
 - title: '5.4.8 Memory management'
   url: 07-implementation/04-dos-donts/08-memory-management  
 
@@ -87,25 +87,25 @@ docs:
 
 - title: '6.1 Guides'
   url: 08-verification/01-guides/toc
- 
+
 - title: '6.2 Tools'
   url: 08-verification/02-tools/toc
- 
+
 - title: '6.3 Frameworks'
   url: 08-verification/03-frameworks/toc
-  
+
 - title: '6.4 Vulnerability management'
   url: 08-verification/04-vulnerability-management/toc
- 
-- title: '6.5 Do's and Dont's'
+
+- title: '6.5 Verification Do''s and Dont''s'
   url: 08-verification/05-dos-donts/toc
- 
+
 - title: '6.5.1 Secure environment'
   url: 08-verification/05-dos-donts/01-secure-environment
- 
+
 - title: '6.5.2 System hardening'
   url: 08-verification/05-dos-donts/02-system-hardening
- 
+
 - title: '6.5.3 Open Source software'
   url: 08-verification/05-dos-donts/03-open-source-software  
 
@@ -123,7 +123,7 @@ docs:
 
 - title: '11. Policy gap evaluation'
   url: 13-policy-gap-evaluation/01-guides/toc
-  
+
 - title: '11.1 Guides'
   url: 13-policy-gap-evaluation/01-guides/toc
 
@@ -132,31 +132,30 @@ docs:
 
 - title: '12.1 Checklist: Define Security Requirements'
   url: 14-checklist/01-define-security-requirements
-  
+
 - title: '12.2 Checklist: Leverage Security Frameworks and Libraries'
   url: 14-checklist/02-frameworks-libraries
-  
+
 - title: '12.3 Checklist: Secure Database Access'
   url: 14-checklist/03-secure-database-access
-  
+
 - title: '12.4 Checklist: Encode and Escape Data'
   url: 14-checklist/04-encode-escape-data
-  
+
 - title: '12.5 Checklist: Validate All Inputs'
   url: 14-checklist/05-validate-inputs
-  
+
 - title: '12.6 Checklist: Implement Digital Identity'
   url: 14-checklist/06-digital-identity
-  
+
 - title: '12.7 Checklist: Enforce Access Controls'
   url: 14-checklist/07-access-controls
-  
+
 - title: '12.8 Checklist: Protect Data Everywhere'
   url: 14-checklist/08-protect-data
-  
+
 - title: '12.9 Checklist: Implement Security Logging and Monitoring'
   url: 14-checklist/09-security-logging-monitoring
-  
+
 - title: '12.10 Checklist: Handle all Errors and Exceptions'
   url: 14-checklist/10-handle-errors-exceptions
-  

--- a/draft/02-toc.md
+++ b/draft/02-toc.md
@@ -14,7 +14,7 @@ permalink: /draft/
 
 ## Table of contents
 
-1 **[Introduction](#introduction)**
+1 **[Introduction](#introduction)**  
 
 2 **[Foundations](#foundations)**  
 2.1 [Security fundamentals](#security-fundamentals)  
@@ -28,11 +28,11 @@ permalink: /draft/
 3.1 [Requirements in practice](#requirements-in-practice)  
 3.2 [Risk profile](#risk-profile)  
 
-4 **[Design](#design)**
+4 **[Design](#design)**  
 4.1 [Threat modeling](#threat-modeling)  
 4.1.1 [Threat modeling in practice](#threat-modeling-in-practice)  
 
-5 **[Implementation](#implementation)**
+5 **[Implementation](#implementation)**  
 5.1 [Documentation](#documentation)  
 5.2 [Dependencies](#dependencies)
 5.3 [Secure Libraries](#secure-libraries)  
@@ -46,12 +46,12 @@ permalink: /draft/
 5.4.7 [File management](#file-management)  
 5.4.8 [Memory management](#memory-management)  
 
-6 **[Verification](#verification)**
+6 **[Verification](#verification)**  
 6.1 [Guides](#verification-guides)  
 6.2 [Tools](#verification-tools)  
 6.3 [Frameworks](#verification-frameworks)  
 6.4 [Vulnerability management](#verification-vulnerability-management)  
-6.5 [Do's and Dont's](#verification-dos-and-donts)
+6.5 [Verification Do's and Dont's](#verification-dos-and-donts)  
 6.5.1 [Secure environment](#secure-environment)  
 6.5.2 [System hardening](#system-hardening)  
 6.5.3 [Open Source software](#open-source-software)  

--- a/draft/toc.md
+++ b/draft/toc.md
@@ -56,7 +56,7 @@ and so the content is expected to frequently change._
 6.2 [Tools](08-verification/02-tools/toc.md)  
 6.3 [Frameworks](08-verification/03-frameworks/toc.md)  
 6.4 [Vulnerability management](08-verification/04-vulnerability-management/toc.md)  
-6.5 [Do's and Dont's](08-verification/05-dos-donts/toc.md)  
+6.5 [Verification Do's and Dont's](08-verification/05-dos-donts/toc.md)  
 6.5.1 [Secure environment](08-verification/05-dos-donts/01-secure-environment.md)  
 6.5.2 [System hardening](08-verification/05-dos-donts/02-system-hardening.md)  
 6.5.3 [Open Source software](08-verification/05-dos-donts/03-open-source-software.md)  


### PR DESCRIPTION
**Summary** :  
This adds pages for the projects shown in the [OWASP project Wayfinder](https://owasp.org/projects/) 
This will make it easier for the leaders of these projects to contribute to the Developer Guide

**Description for the changelog** :  
Add pages to correspond with Wayfinder

**Other info** :  

