### PR TITLE
chore: CRS naming, Coraza link typo

### DIFF
--- a/_data/draft.yaml
+++ b/_data/draft.yaml
@@ -268,7 +268,7 @@ docs:
 - title: '9.3 ModSecurity Web Application Firewall'
   url: operations/modsecurity_waf/
 
-- title: '9.4 ModSecurity Core Rule Set'
+- title: '9.4 OWASP CRS'
   url: operations/modsecurity_core_rule_set
 
 - title: '10. Metrics'

--- a/draft/02-toc.md
+++ b/draft/02-toc.md
@@ -111,7 +111,7 @@ permalink:
 9.1 [DevSecOps Guideline](#devsecops-guideline)  
 9.2 [Coraza Web Application Firewall](#coraza-web-application-firewall)  
 9.3 [ModSecurity Web Application Firewall](#modsecurity-web-application-firewall)  
-9.4 [ModSecurity Core Rule Set](#modSecurity-core-rule-set)  
+9.4 [OWASP CRS](#modSecurity-core-rule-set)  
 
 10 **[Metrics](#metrics)**  
 

--- a/draft/11-operations/00-toc.md
+++ b/draft/11-operations/00-toc.md
@@ -27,7 +27,7 @@ Operations generally cover the security practices:
 * [Environment Management][sammoem] such as configuration hardening, patching and updating
 * [Operational Management][sammoom] which includes data protection and system / legacy management
 
-OWASP projects provide the Core Rule Set that is used for both Coraza and ModSecurity web application firewalls,
+OWASP projects provide the CRS that is used for both Coraza and ModSecurity web application firewalls,
 which are widely used for data and system management.
 
 Sections:

--- a/draft/11-operations/02-coraza.md
+++ b/draft/11-operations/02-coraza.md
@@ -18,7 +18,7 @@ permalink: /draft/operations/coraza_waf/
 
 The [OWASP Coraza][coraza-project] project provides a golang enterprise-grade Web Application Firewall framework
 that supports the [ModSecurity][modsec] seclang language
-and is completely compatible with the OWASP [Core Rule Set][modcrs] (CRS).
+and is completely compatible with the OWASP [CRS][crs].
 Coraza is in active development as an OWASP Production code project,
 with the first stable version released in September 2021 and several releases since then.
 
@@ -26,7 +26,7 @@ with the first stable version released in September 2021 and several releases si
 
 The [Coraza][coraza] Web Application Firewall framework is used to enforce policies,
 providing a first line of defense to stop attack on web applications and servers.
-Coraza  can be configured using the OWASP [Core Rule Set][modcrs] and also custom policies can be created.
+Coraza  can be configured using the OWASP [CRS][crs] and also custom policies can be created.
 
 Coraza can be deployed:
 
@@ -67,7 +67,7 @@ then [submit an issue][issue1102] or [edit on GitHub][edit1102].
 [coraza-wasm]: https://github.com/corazawaf/coraza-proxy-wasm
 [edit1102]: https://github.com/OWASP/www-project-developer-guide/blob/main/draft/11-operations/02-coraza.md
 [issue1102]: https://github.com/OWASP/www-project-developer-guide/issues/new?labels=content&template=request.md&title=Update:%2011-operations/02-coraza
-[modcrs]: https://coreruleset.org/
+[crs]: https://coreruleset.org/
 [modsec]: https://owasp.org/www-project-modsecurity/
 
 \newpage

--- a/draft/11-operations/03-modsecurity.md
+++ b/draft/11-operations/03-modsecurity.md
@@ -27,7 +27,7 @@ ModSecurity itself has a long history as an open source project, the first relea
 and is widely used as a web application firewall for cloud and on-premises web servers.
 
 The ModSecurity WAF needs to be configured in operational deployments,
-and this can be done using the OWASP ModSecurity [Core Rule Set][modcrs].
+and this can be done using the OWASP [CRS][crs].
 
 #### Why use ModSecurity?
 
@@ -43,7 +43,7 @@ or deployed within the web server itself, to provide protection against HTTP att
 The rules applied to the HTTP traffic are provided as configuration to ModSecurity,
 and these rules allow many different actions to be applied such as blocking traffic, redirecting requests, and many more.
 See the documentation for [deploying and running][modsec-docs] ModSecurity,
-along with the documentation on configuring ModSecurity with the [Core Rule Set][modcrs].
+along with the documentation on configuring ModSecurity with the [CRS][crs].
 
 ----
 
@@ -53,7 +53,7 @@ then [submit an issue][issue1103] or [edit on GitHub][edit1103].
 [coraza]: https://coraza.io/
 [edit1103]: https://github.com/OWASP/www-project-developer-guide/blob/main/draft/11-operations/03-modsecurity.md
 [issue1103]: https://github.com/OWASP/www-project-developer-guide/issues/new?labels=content&template=request.md&title=Update:%2011-operations/03-modsecurity
-[modcrs]: https://coreruleset.org/
+[crs]: https://coreruleset.org/
 [modsec]: https://owasp.org/www-project-modsecurity/
 [modsec-docs]: https://www.modsecurity.org/
 [modsec-press]: https://owasp.org/blog/2024/01/09/ModSecurity.html

--- a/draft/11-operations/04-modsecurity-crs.md
+++ b/draft/11-operations/04-modsecurity-crs.md
@@ -1,6 +1,6 @@
 ---
 
-title: ModSecurity Core Rule Set
+title: OWASP CRS
 layout: col-document
 tags: OWASP Developer Guide
 contributors: Jon Gadsden
@@ -26,14 +26,14 @@ permalink: /draft/operations/modsecurity_core_rule_set/
 
 ### 9.4 OWASP CRS
 
-The OWASP CRS[modcrs-project] project is a set of generic attack detection rules
+The [OWASP CRS][crs-project] project, formerly known as Core Rule Set, is a set of generic attack detection rules
 for use with [ModSecurity][modsec] compatible web application firewalls such as [OWASP Coraza][coraza].
-CRS is an OWASP [Flagship tool project][modcrs-project] and can be [downloaded][modcrs-download]
+CRS is an OWASP [Flagship tool project][crs-project] and can be [downloaded][crs-download]
 for either Apache or IIS/Nginx web servers.
 
 #### What is the CRS?
 
-The [CRS][modcrs] are attack detection rules for use with [ModSecurity][modsec],
+The [CRS][crs] are attack detection rules for use with [ModSecurity][modsec],
 [Coraza][coraza] and other ModSecurity compatible web application firewalls.
 The CRS aims to protect web applications from a wide range of attacks with a minimum of false alerts.
 The CRS provides protection against many common attack categories, including those in the OWASP Top Ten.
@@ -41,7 +41,7 @@ The CRS provides protection against many common attack categories, including tho
 #### Why use it?
 
 If an organization is using a Coraza, ModSecurity or compatible Web Application Firewall (WAF)
-then it is very likely that the [CRS][modcrs] is already in use by this WAF.
+then it is very likely that the [CRS][crs] is already in use by this WAF.
 The CRS provides the policy for the Coraza / Modsecurity engine so that traffic to a web application is inspected
 for various attacks and malicious traffic is blocked.
 
@@ -50,7 +50,7 @@ for various attacks and malicious traffic is blocked.
 The use of the CRS assumes that a ModSecurity, Coraza or compatible WAF has been installed.
 Refer to the [Coraza tutorial][coraza-tutorial] or the [ModSecurity][modsec-docs] on how to do this.
 
-To get started with CRS refer to the CRS [installation instructions][modcrs-download].
+To get started with CRS refer to the CRS [installation instructions][crs-download].
 
 The OWASP Spotlight series provides an overview of how to use this CRS:
 'Project 3 - [Core Rule Set (CRS) - 1st Line of Defense][spotlight03]'.
@@ -64,9 +64,9 @@ then [submit an issue][issue1104] or [edit on GitHub][edit1104].
 [coraza-tutorial]: https://coraza.io/docs/tutorials/quick-start/
 [edit1104]: https://github.com/OWASP/www-project-developer-guide/blob/main/draft/11-operations/04-modsecurity-crs.md
 [issue1104]: https://github.com/OWASP/www-project-developer-guide/issues/new?labels=content&template=request.md&title=Update:%2011-operations/04-modsecurity-crs
-[modcrs]: https://coreruleset.org/
-[modcrs-download]: https://coreruleset.org/docs/deployment/install/
-[modcrs-project]: https://owasp.org/www-project-modsecurity-core-rule-set/
+[crs]: https://coreruleset.org/
+[crs-download]: https://coreruleset.org/docs/deployment/install/
+[crs-project]: https://owasp.org/www-project-modsecurity-core-rule-set/
 [modsec]: https://owasp.org/www-project-modsecurity/
 [modsec-docs]: https://www.modsecurity.org/
 [spotlight03]: https://youtu.be/88ZMKpiZbRI

--- a/draft/11-operations/04-modsecurity-crs.md
+++ b/draft/11-operations/04-modsecurity-crs.md
@@ -24,35 +24,35 @@ permalink: /draft/operations/modsecurity_core_rule_set/
 
 ![CRS logo](../../../assets/images/logos/crs.png "OWASP CRS"){: .image-right }
 
-### 9.4 ModSecurity Core Rule Set
+### 9.4 OWASP CRS
 
-The OWASP ModSecurity [Core Rule Set][modcrs-project] (CRS) project is a set of generic attack detection rules
+The OWASP CRS[modcrs-project] project is a set of generic attack detection rules
 for use with [ModSecurity][modsec] compatible web application firewalls such as [OWASP Coraza][coraza].
 CRS is an OWASP [Flagship tool project][modcrs-project] and can be [downloaded][modcrs-download]
 for either Apache or IIS/Nginx web servers.
 
-#### What is the Core Rule Set?
+#### What is the CRS?
 
-The [Core Rule Set][modcrs] (CRS) are attack detection rules for use with [ModSecurity][modsec],
-[Coraza[coraza] and other ModSecurity compatible web application firewalls.
+The [CRS][modcrs] are attack detection rules for use with [ModSecurity][modsec],
+[Coraza][coraza] and other ModSecurity compatible web application firewalls.
 The CRS aims to protect web applications from a wide range of attacks with a minimum of false alerts.
 The CRS provides protection against many common attack categories, including those in the OWASP Top Ten.
 
 #### Why use it?
 
 If an organization is using a Coraza, ModSecurity or compatible Web Application Firewall (WAF)
-then it is very likely that the [Core Rule Set][modcrs] is already in use by this WAF.
+then it is very likely that the [CRS][modcrs] is already in use by this WAF.
 The CRS provides the policy for the Coraza / Modsecurity engine so that traffic to a web application is inspected
 for various attacks and malicious traffic is blocked.
 
 #### How to use it
 
-The use of the Core Rule Set assumes that a ModSecurity, Coraza or compatible WAF has been installed.
+The use of the CRS assumes that a ModSecurity, Coraza or compatible WAF has been installed.
 Refer to the [Coraza tutorial][coraza-tutorial] or the [ModSecurity][modsec-docs] on how to do this.
 
-To get started with CRS refer to the Core Rule Set [installation instructions][modcrs-download].
+To get started with CRS refer to the CRS [installation instructions][modcrs-download].
 
-The OWASP Spotlight series provides an overview of how to use this Core Rule Set:
+The OWASP Spotlight series provides an overview of how to use this CRS:
 'Project 3 - [Core Rule Set (CRS) - 1st Line of Defense][spotlight03]'.
 
 ----

--- a/draft/11-operations/toc.md
+++ b/draft/11-operations/toc.md
@@ -38,7 +38,7 @@ Operations generally cover the security practices:
 * [Environment Management][sammoem] such as configuration hardening, patching and updating
 * [Operational Management][sammoom] which includes data protection and system / legacy management
 
-OWASP projects provide the Core Rule Set that is used for both Coraza and ModSecurity web application firewalls,
+OWASP projects provide the CRS that is used for both Coraza and ModSecurity web application firewalls,
 which are widely used for data and system management.
 
 Sections:
@@ -46,7 +46,7 @@ Sections:
 9.1 [DevSecOps Guideline](01-devsecops.md)  
 9.2 [Coraza Web Application Firewall](02-coraza.md)  
 9.3 [ModSecurity Web Application Firewall](03-modsecurity.md)  
-9.4 [ModSecurity Core Rule Set](04-modsecurity-crs.md)  
+9.4 [OWASP CRS](04-modsecurity-crs.md)  
 
 ----
 

--- a/draft/toc.md
+++ b/draft/toc.md
@@ -115,7 +115,7 @@ This draft version has the latest contributions to the Developer Guide so expect
 9.1 [DevSecOps Guideline](11-operations/01-devsecops.md)  
 9.2 [Coraza Web Application Firewall](11-operations/02-coraza.md)  
 9.3 [ModSecurity Web Application Firewall](11-operations/03-modsecurity.md)  
-9.4 [ModSecurity Core Rule Set](11-operations/04-modsecurity-crs.md)  
+9.4 [OWASP CRS](11-operations/04-modsecurity-crs.md)  
 
 10 **[Metrics](12-metrics/toc.md)**  
 


### PR DESCRIPTION
Hi there, proposing minor changes for the CRS page. 
**Summary** :  
- Adheres to https://github.com/OWASP/www-project-modsecurity-core-rule-set/pull/18 updating the Core rule set project name to `CRS`
- Adds a `]` to properly render Coraza link.