### PR TITLE
Fix a typo in 03-introduction.md

### DIFF
--- a/draft/03-introduction.md
+++ b/draft/03-introduction.md
@@ -47,7 +47,7 @@ OWASP Software Assurance Maturity Model ([SAMM][samm]) and describes the OWASP p
 referenced in the OWASP [Application Security Wayfinder][intstand] project.
 
 This guide does not seek to replicate the many excellent sources on specific security topics;
-it will rarely tries to go into details on a subject and instead provides links for greater depth on these security topics.
+it rarely tries to go into detail on a subject and instead provides links for greater depth on these security topics.
 Instead the content of the Developer Guide aims to be accessible, introducing  practical security concepts
 and providing enough detail to get developers started on various OWASP tools and documents.
 


### PR DESCRIPTION
The sentence was not grammatically correct. The same sentence in another file was edited a few months ago in https://github.com/OWASP/www-project-developer-guide/commit/26adb50e935d3b1bd9923cf41ffaeb35c0b64c75#diff-a48746cae70c44e7e105b594aad338ddd105c93c1cb445a40ba6aab785ba69e5R27
