### PR TITLE
Use EN-US consistently

### DIFF
--- a/.spellcheck-en.yaml
+++ b/.spellcheck-en.yaml
@@ -2,6 +2,7 @@ matrix:
 - name: Markdown
   aspell:
     lang: en
+    d: en_US
   dictionary:
     wordlists:
     - .wordlist-en.txt

--- a/.wordlist-en.txt
+++ b/.wordlist-en.txt
@@ -6,6 +6,7 @@ ARP
 ASVS
 AUTH
 Adoptium
+Analyser
 Andra
 Andreas
 AngularJS
@@ -145,6 +146,8 @@ MASTG
 MASVS
 MASWE
 MBOM
+MITRE
+MITRE's
 MOBI
 MSTG
 MacOS

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ and also the [developer guide][dgrelease] itself.
 This guide is one of the original documents from OWASP and so has a long history.
 The [original DevGuide repository][devguide] has many of the [previous versions][versions]
 going back to the [original version 1.0][original] from 2002.
-Note that the original DevGuide repository has been deprecated in favour of this one.
+Note that the original DevGuide repository has been deprecated in favor of this one.
 
 The source for the latest draft developer guide can be found under the ['draft'][draft] directory.
 The source is in markdown and is used to create the developer guide HTML, PDF and ePub outputs.

--- a/contributing.md
+++ b/contributing.md
@@ -64,7 +64,7 @@ or a single project such as the OWASP 'Threat Dragon' Builder/Tool project.
 
 Sub-sections that describe an individual project should follow the same structure:
 
-1. Introduction, summarising the project at a very high level:
+1. Introduction, summarizing the project at a very high level:
   _supply a couple of sentences on the project including its status as an OWASP project and where to find it_
 2. The 'What', explaining what the project is to a general level:
   _go into more detail about the project so that a developer can gain an overview of what this project can provide for them_
@@ -89,7 +89,7 @@ The pull requests have checks applied to them:
 
 1. Link checker for any broken links; if there is an imperative for a broken link then add it to `.lycheeignore`
 2. Markdown lint that ensures the markdown is consistent and valid
-3. Spell checker; new words that are not recognised can be added to `/.wordlist.txt`
+3. Spell checker; new words that are not recognized can be added to `/.wordlist.txt`
 
 if all these checks pass then both the PDF and ePub versions of the guide are provided as github artifacts.
 

--- a/draft/04-foundations/02-secure-development.md
+++ b/draft/04-foundations/02-secure-development.md
@@ -140,7 +140,7 @@ There are many OWASP tools and resources to help build security into the SDLC.
 
 * **Application security testing**: there are various types of security testing that can be automated on pull-request,
    merge or nightlies - or indeed manually but they are most powerful when automated. Commonly there is
-   Static Application Security Testing (SAST), which analyses the code without running it,
+   Static Application Security Testing (SAST), which analyzes the code without running it,
    and Dynamic Application Security Testing (DAST), which applies input to the application while running it in a sandbox
    or other isolated environments.
    Interactive Application Security Testing (IAST) is designed to be run manually as well as being automated,

--- a/draft/04-foundations/03-security-principles.md
+++ b/draft/04-foundations/03-security-principles.md
@@ -85,7 +85,7 @@ A security principle in which a person or process is given only the minimum leve
 that is necessary for that person or process to complete an assigned operation.
 This right must be given only for a minimum amount of time that is necessary to complete the operation.
 
-This helps to limits the damage when a system is compromised by minimising the ability of an attacker
+This helps to limits the damage when a system is compromised by minimizing the ability of an attacker
 to escalate privileges both laterally or vertically.
 In order to apply this [principle of least privilege][elp] proper granularity
 of privileges and permissions should be established.

--- a/draft/04-foundations/05-top-ten.md
+++ b/draft/04-foundations/05-top-ten.md
@@ -39,7 +39,7 @@ to web applications and seeks to rank them in importance and severity.
 
 The list has changed over time, with some threat types becoming more of a problem to web applications
 and other threats becoming less of a risk as technologies change.
-The [latest version][top10] was issued in 2021 and each category is summarised below.
+The [latest version][top10] was issued in 2021 and each category is summarized below.
 
 Note that there are various 'OWASP Top Ten' projects, for example the 'OWASP Top 10 for Large Language Model Applications',
 so to avoid confusion the context should be noted when referring to these lists.
@@ -109,7 +109,7 @@ a common example of misconfiguration where default accounts and their passwords 
 These passwords and accounts are usually well-known and provide an easy way for malicious actors to compromise applications.
 
 Both the [OWASP Top 10 A05:2021][a05] and the linked [OWASP Cheat Sheets][a05cs] provide strategies to establish
-a concerted, repeatable application security configuration process to minimise misconfiguration.
+a concerted, repeatable application security configuration process to minimize misconfiguration.
 
 #### A06:2021 Vulnerable and Outdated Components
 
@@ -123,7 +123,7 @@ making it easy for vulnerable third party software dependencies to be exploited 
 Risk [A06 Vulnerable and Outdated Components][a06] underlines the importance of this activity,
 and recommends that fixes and upgrades to the underlying platform, frameworks, and dependencies
 are based on a risk assessment and done in a 'timely fashion'.
-Several tools can used to analyse dependencies and flag vulnerabilities, refer to the [Cheat Sheets][a06cs] for these.
+Several tools can used to analyze dependencies and flag vulnerabilities, refer to the [Cheat Sheets][a06cs] for these.
 
 #### A07:2021 Identification and Authentication Failures
 

--- a/draft/05-requirements/03-opencre.md
+++ b/draft/05-requirements/03-opencre.md
@@ -24,7 +24,7 @@ and the Application Security Wayfinder, it is an OWASP documentation project wit
 
 #### What is the Integration Standards project?
 
-The [Integration Standards][intstand] project is at the centre of the OWASP project community;
+The [Integration Standards][intstand] project is at the center of the OWASP project community;
 it provides guidance on how to navigate and use the many projects within OWASP.
 It does this in two ways, first is the [Application Security Wayfinder][intstand] which provides a visual map
 of the most important OWASP projects - as of August 2024 there are 345 [OWASP projects][projects]

--- a/draft/06-design/00-toc.md
+++ b/draft/06-design/00-toc.md
@@ -23,7 +23,7 @@ Secure Architecture Design looks at the selection and composition of components 
 Technology Management looks at the security of supporting technologies used during development, deployment and operations,
 such as development stacks and tooling, deployment tooling, and operating systems and tooling.
 
-A secure design will help establish secure defaults, minimise the attack surface area
+A secure design will help establish secure defaults, minimize the attack surface area
 and fail securely to well-defined and understood defaults.
 It will also consider and follow various principles, such as:
 

--- a/draft/06-design/01-threat-modeling/01-threat-modeling.md
+++ b/draft/06-design/01-threat-modeling/01-threat-modeling.md
@@ -165,16 +165,16 @@ Finally, carry out a retrospective activity over the work identified to check
 quality, feasibility, progress, or planning.
 
 The OWASP [Threat Modeling Playbook][tmpb] goes into these practicalities in more detail
-and provides strategies for maintaining threat modeling within an organisation.
+and provides strategies for maintaining threat modeling within an organization.
 
 #### How to do it
 
 There is no one process for threat modeling.
-How it is done in practice will vary according to the organisation's culture,
+How it is done in practice will vary according to the organization's culture,
 according to what type of system / application is being modeled
 and according to preferences of the development team itself.
 The various techniques and concepts are discussed in the [Threat Modeling Cheat Sheet][cstm]
-and can be summarised:
+and can be summarized:
 
 1. Terminology: try to use standard terms such as actors, trust boundaries, etc as this will help convey these concepts
 2. Scope: be clear what is being modeled and keep within this scope
@@ -182,7 +182,7 @@ and can be summarised:
 4. Decompose: break the system being modeled into manageable pieces
 5. Trust: identify your trust boundaries, consider [network segmentation][ccsnet]
 6. Agents: identify who the actors are (malicious or otherwise) and what they can do
-7. Categorise: prioritise the threats taking into account probability, impact and any other factors
+7. Categorize: prioritize the threats taking into account probability, impact and any other factors
 8. Remediation: be sure to decide what to do about any threats identified, the whole reason for threat modeling
 
 It is worth saying this again: there are many ways to do threat modeling,
@@ -209,7 +209,7 @@ at the very least the changes should not make the security worse - and ideally t
 
 **Tools are secondary**:
 
-It is good to standardise threat modeling tools across an organisation,
+It is good to standardize threat modeling tools across an organization,
 but also allow teams to choose how they record their threat models.
 If one team decides to use Threat Dragon, for example, and another wants to use a drawing board,
 then that is usually fine.
@@ -227,7 +227,7 @@ malicious actors (external or internal) trying to subvert your system.
 
 **Choose your methodology**:
 
-It is a good strategy to choose a threat categorisation methodology for the whole organisation
+It is a good strategy to choose a threat categorization methodology for the whole organization
 and then try and keep to it.
 For example this could be [STRIDE][stride] or [LINDDUN][linddun], but if the CIA triad provides enough granularity
 then that is also a perfectly good choice.
@@ -254,7 +254,7 @@ then that is also a perfectly good choice.
 * [Threagile](https://threagile.io), an open source project that provides for Agile threat modeling
 * Microsoft [Threat Modeling Tool][TMT], a widely used tool throughout the security community and free to download
 * [threatspec](https://github.com/threatspec/threatspec), an open source tool based on comments inline with code
-* Mitre's Common Attack Pattern Enumeration and Classification ([CAPEC][capec])
+* MITRE's Common Attack Pattern Enumeration and Classification ([CAPEC][capec])
 * NIST [Common Vulnerability Scoring System Calculator][nist-cvss]
 
 ----

--- a/draft/06-design/01-threat-modeling/04-cornucopia.md
+++ b/draft/06-design/01-threat-modeling/04-cornucopia.md
@@ -64,7 +64,7 @@ To provide context the Cornucopia Website App cards reference other projects:
 * OWASP Application Security Verification Standard ([ASVS][asvs])
 * OWASP Secure Coding Practices ([SCP][scp-v21]]) quick reference guide
 * OWASP [AppSensor][appsensor]
-* Mitre's Common Attack Pattern Enumeration and Classification ([CAPEC][capec])
+* MITRE's Common Attack Pattern Enumeration and Classification ([CAPEC][capec])
 * [SAFEcode][safecode]
 
 The SCP quick reference guide has now been incorporated as part of this [Developer Guide](../02-web-app-checklist/toc.md).
@@ -85,7 +85,7 @@ For context the Cornucopia Mobile App cards reference these other projects:
 
 * OWASP Mobile Application Security Verification Standard ([MASVS][masvs])
 * OWASP Mobile Application Security Testing Guide ([MASTG][mastg])
-* Mitre's Common Attack Pattern Enumeration and Classification ([CAPEC][capec])
+* MITRE's Common Attack Pattern Enumeration and Classification ([CAPEC][capec])
 * [SAFEcode][safecode]
 
 #### Ecommerce Website Edition

--- a/draft/06-design/01-threat-modeling/06-toolkit.md
+++ b/draft/06-design/01-threat-modeling/06-toolkit.md
@@ -48,7 +48,7 @@ and goes into detail on each concept :
 * Remediation for threats / vulnerabilities
 
 The OWASP [Threat Modeling Playbook][tmpb] (OTMP) is an OWASP Incubator project that describes how to
-create and nurture a good threat modeling culture within the organisation itself.
+create and nurture a good threat modeling culture within the organization itself.
 
 #### Cheat Sheets for Threat Modeling
 

--- a/draft/06-design/02-web-app-checklist/00-toc.md
+++ b/draft/06-design/02-web-app-checklist/00-toc.md
@@ -19,7 +19,7 @@ Checklists are a valuable resource for development teams.
 They provide structure for establishing good practices and processes
 and are also useful during code reviews and design activities.
 
-The checklists that follow are general lists that are categorised to follow the controls listed in the
+The checklists that follow are general lists that are categorized to follow the controls listed in the
 [OWASP Top 10 Proactive Controls][proactive10] project.
 These checklists provide suggestions that certainly should be tailored to
 an individual project's requirements and environment; they are not meant to be followed in their entirety.

--- a/draft/06-design/02-web-app-checklist/02-frameworks-libraries.md
+++ b/draft/06-design/02-web-app-checklist/02-frameworks-libraries.md
@@ -57,7 +57,7 @@ In addition consider the following extra checks for frameworks and libraries.
 1. Validate safe functionality for all secondary applications and third party libraries
 1. Create and maintain an inventory catalog of all third party libraries using Software Composition Analysis (SCA)
 1. Proactively keep all third party libraries and components up to date
-1. Reduce the attack surface by encapsulating the library and expose only the required behaviour into your software
+1. Reduce the attack surface by encapsulating the library and expose only the required behavior into your software
 1. Use tested and approved managed code rather than creating new unmanaged code for common tasks
 1. Utilize task specific built-in APIs to conduct operating system tasks
 1. Do not allow the application to issue commands directly to the Operating System

--- a/draft/06-design/02-web-app-checklist/toc.md
+++ b/draft/06-design/02-web-app-checklist/toc.md
@@ -30,7 +30,7 @@ Checklists are a valuable resource for development teams.
 They provide structure for establishing good practices and processes
 and are also useful during code reviews and design activities.
 
-The checklists that follow are general lists that are categorised to follow the controls listed in the
+The checklists that follow are general lists that are categorized to follow the controls listed in the
 [OWASP Top 10 Proactive Controls][proactive10] project.
 These checklists provide suggestions that certainly should be tailored to
 an individual project's requirements and environment; they are not meant to be followed in their entirety.

--- a/draft/06-design/toc.md
+++ b/draft/06-design/toc.md
@@ -34,7 +34,7 @@ Secure Architecture Design looks at the selection and composition of components 
 Technology Management looks at the security of supporting technologies used during development, deployment and operations,
 such as development stacks and tooling, deployment tooling, and operating systems and tooling.
 
-A secure design will help establish secure defaults, minimise the attack surface area
+A secure design will help establish secure defaults, minimize the attack surface area
 and fail securely to well-defined and understood defaults.
 It will also consider and follow various principles, such as:
 

--- a/draft/07-implementation/00-toc.md
+++ b/draft/07-implementation/00-toc.md
@@ -30,7 +30,7 @@ Implementation should include security practices such as :
 Implementation is where the application / system begins to take shape; source code is written and tests are created.
 The implementation of the application follows a secure development lifecycle, with security built in from the start.
 
-The implementation will use a secure method of source code control and storage to fulfil the design security requirements.
+The implementation will use a secure method of source code control and storage to fulfill the design security requirements.
 The development team will be referring to documentation advising them of best practices,
 they will be using secure libraries wherever possible in addition to checking and tracking external dependencies.
 

--- a/draft/07-implementation/01-documentation/03-cheatsheets.md
+++ b/draft/07-implementation/01-documentation/03-cheatsheets.md
@@ -61,7 +61,7 @@ The OWASP Spotlight series provides a good overview of using this documentation:
 
 There are many cheat sheets in the OWASP Cheat Sheet Series;
 91 of them as of March 2024 and this number is set to increase.
-The OWASP community recognises that this may become overwhelming at first, and so has arranged them in various ways:
+The OWASP community recognizes that this may become overwhelming at first, and so has arranged them in various ways:
 
 * [Alphabetically][cheatsheet-alpha]
 * Indexed to follow the [ASVS project][csasvs] or the [MASVS project][csmasvs]

--- a/draft/07-implementation/02-dependencies/02-dependency-track.md
+++ b/draft/07-implementation/02-dependencies/02-dependency-track.md
@@ -16,7 +16,7 @@ permalink: /draft/implementation/dependencies/dependency_track/
 
 OWASP Dependency-Track is an intelligent platform for Component Analysis including Third Party Software.
 It allows organizations to identify and reduce risk in the [software supply chain][cschain]
-using its ability to analyse a Software Bill of Materials (SBOM).
+using its ability to analyze a Software Bill of Materials (SBOM).
 
 The [Dependency-Track][deptrack-project] is an OWASP Flagship project
 and can be installed using a docker-compose file from the Dependency-Track [website][deptrack].

--- a/draft/07-implementation/03-secure-libraries/00-toc.md
+++ b/draft/07-implementation/03-secure-libraries/00-toc.md
@@ -15,7 +15,7 @@ order:
 
 ### 5.3 Secure libraries
 
-The use of secure libraries is part of the technology management that helps to fulfil security requirements.
+The use of secure libraries is part of the technology management that helps to fulfill security requirements.
 Standard libraries enable the adoption of common design patterns and security solutions,
 and provide standardized technologies and frameworks that can be used throughout different applications.
 

--- a/draft/07-implementation/03-secure-libraries/toc.md
+++ b/draft/07-implementation/03-secure-libraries/toc.md
@@ -26,7 +26,7 @@ permalink: /draft/implementation/secure_libraries/
 
 ### 5.3 Secure libraries
 
-The use of secure libraries is part of the technology management that helps to fulfil security requirements.
+The use of secure libraries is part of the technology management that helps to fulfill security requirements.
 Standard libraries enable the adoption of common design patterns and security solutions,
 and provide standardized technologies and frameworks that can be used throughout different applications.
 

--- a/draft/07-implementation/04-maswe.md
+++ b/draft/07-implementation/04-maswe.md
@@ -59,7 +59,7 @@ The MASWE is a valuable list of what can go wrong with mobile applications along
 
 #### How to use it
 
-The Common Weakness Enumeration ([CWE][cwe]), published by Mitre, can be used by security architects
+The Common Weakness Enumeration ([CWE][cwe]), published by MITRE, can be used by security architects
 so they are aware of what weaknesses and potential vulnerabilities that could be present in an application.
 Development teams can use the CWE as a reference to these weaknesses and to help understanding of any mitigations.
 These are just two examples of how the CWE is widely used.
@@ -77,7 +77,7 @@ This list is just a starting point; there are many uses for the MASWE.
 
 * Mobile Application Security ([MAS][masproject]) project
 * MAS Weakness Enumeration ([MASWE][maswe])
-* Mitre Common Weakness Enumeration ([CWE][cwe])
+* MITRE Common Weakness Enumeration ([CWE][cwe])
 * MAS Verification Standard ([MASVS][masvs])
 * MAS [Checklist][masc]
 * MAS Testing Guide ([MASTG][mastg])

--- a/draft/07-implementation/toc.md
+++ b/draft/07-implementation/toc.md
@@ -41,7 +41,7 @@ Implementation should include security practices such as :
 Implementation is where the application / system begins to take shape; source code is written and tests are created.
 The implementation of the application follows a secure development lifecycle, with security built in from the start.
 
-The implementation will use a secure method of source code control and storage to fulfil the design security requirements.
+The implementation will use a secure method of source code control and storage to fulfill the design security requirements.
 The development team will be referring to documentation advising them of best practices,
 they will be using secure libraries wherever possible in addition to checking and tracking external dependencies.
 

--- a/draft/08-verification/02-tools/03-owtf.md
+++ b/draft/08-verification/02-tools/03-owtf.md
@@ -27,7 +27,7 @@ permalink: /draft/verification/tools/offensive_web_testing_framework/
 ### 6.2.3 Offensive Web Testing Framework
 
 OWASP Offensive Web Testing Framework ([OWTF][owtf]) is a penetration test tool
-that provides pen-testers with a framework for organising and running security test suites.
+that provides pen-testers with a framework for organizing and running security test suites.
 It also helps align the pen-testing to various standards and security guides,
 allowing the testing to be more creative and comprehensive.
 
@@ -36,7 +36,7 @@ and can be downloaded from the project's github repository [release area][owtfdo
 
 #### What is OWTF?
 
-The [OWTF][owtf]tool is a penetration test framework used to organise and run suites of security and pen-testing tools.
+The [OWTF][owtf]tool is a penetration test framework used to organize and run suites of security and pen-testing tools.
 It is designed to be run on [Kali Linux][kali]; it can also be run on MacOS but with some modification of scripts and paths.
 
 OWTF is very much a penetration tester's tool; there is an expectation that the

--- a/draft/09-training-education/00-toc.md
+++ b/draft/09-training-education/00-toc.md
@@ -21,7 +21,7 @@ within the [Governance][sammg] business function.
 
 The goal of security training and education is to increase the awareness of application security threats and risks
 along with security best practices and secure software design principles.
-The security awareness training should be customised for all roles currently involved in the management,
+The security awareness training should be customized for all roles currently involved in the management,
 development, testing, or auditing of the applications and systems.
 In addition a Learning Management System or equivalent should be in place to track
 the employee training and certification processes.

--- a/draft/09-training-education/01-vulnerable-apps/02-webgoat.md
+++ b/draft/09-training-education/01-vulnerable-apps/02-webgoat.md
@@ -58,7 +58,7 @@ Reasons to use WebGoat:
 * Practical learning how to exploit web applications
 * Ready made target during talks and demonstration on penetration testing
 * Evaluating dynamic application security testing (DAST) tools; they should identify the known vulnerabilities
-* Practising penetration testing skills
+* Practicing penetration testing skills
 * and there will be more
 
 #### How to use WebGoat
@@ -108,7 +108,7 @@ and navigating to `http://localhost:3000/`.
 
 * Try the WebGoat lessons, they will certainly inform and educate
 * Exercise available attack tools against WebGoat
-* Use WebGoat in demonstrations of your favourite attack chains
+* Use WebGoat in demonstrations of your favorite attack chains
 * Use WebGoat material in presentations on vulnerabilities
 
 There are various ways of configuring WebGoat, see the [github repo][goatgithub] for more details.

--- a/draft/09-training-education/09-snakes-ladders.md
+++ b/draft/09-training-education/09-snakes-ladders.md
@@ -38,7 +38,7 @@ This documentation project is an OWASP Lab project, aimed at security builders a
 Yes, it really is the snakes & ladders game, but for web and [mobile application security][csmas].
 [It is played][snakeshowto] by two competing teams, possibly accompanied by beer and pretzels.
 
-In the board game for web applications, the virtuous behaviours (ladders) are secure coding practices
+In the board game for web applications, the virtuous behaviors (ladders) are secure coding practices
 (using the OWASP [Proactive Controls][proactive10]) and the vices (snakes)
 are application security risks from the [OWASP Top Ten][top102017] 2017 version.
 
@@ -53,7 +53,7 @@ The web application version can be downloaded for various languages:
 * [Chinese](https://github.com/OWASP/www-project-snakes-and-ladders/tree/master/assets/files/web/ZH) (ZH)
 
 The board game for mobile applications uses the mobile controls
-detailed in the [OWASP Mobile Top 10][mobile10controls] as the virtuous behaviours.
+detailed in the [OWASP Mobile Top 10][mobile10controls] as the virtuous behaviors.
 The vices are the [Mobile Top 10 risks][mobile10-2014] from the 2014 version of the project.
 
 The mobile application version is available as a download in
@@ -65,12 +65,12 @@ and [Japanese](https://github.com/OWASP/www-project-snakes-and-ladders/tree/mast
 This board game was created so that it could be used as an ice-breaker in application security training.
 It also has wider appeal as learning materials for developers or simply as a promotional hand-out.
 
-To cover all of that, the Snakes & Ladders project team summarise it as:
+To cover all of that, the Snakes & Ladders project team summarize it as:
 
 "OWASP Snakes and Ladders is meant to be used by software programmers, big and small"
 
 The game is quite lightweight; so it is meant to be just some fun with some learning attached,
-and is not intended to have the same rigour or depth as the card game [Cornucopia][cornucopia].
+and is not intended to have the same rigor or depth as the card game [Cornucopia][cornucopia].
 
 When the project was first created there was a print run of the game on heavy duty paper.
 These were available at conferences and meetings - they were also available to be purchased online

--- a/draft/09-training-education/toc.md
+++ b/draft/09-training-education/toc.md
@@ -32,7 +32,7 @@ within the [Governance][sammg] business function.
 
 The goal of security training and education is to increase the awareness of application security threats and risks
 along with security best practices and secure software design principles.
-The security awareness training should be customised for all roles currently involved in the management,
+The security awareness training should be customized for all roles currently involved in the management,
 development, testing, or auditing of the applications and systems.
 In addition a Learning Management System or equivalent should be in place to track
 the employee training and certification processes.

--- a/draft/10-culture-process/01-security-culture.md
+++ b/draft/10-culture-process/01-security-culture.md
@@ -33,7 +33,7 @@ arranged under various topic headings.
 * [Security team collaboration][culturegoal]
 * [Security champions][culturechamps]
 * [Activities][cultureacts]
-* [Threat modelling][culturetm]
+* [Threat modeling][culturetm]
 * [Security testing][culturetest]
 * [Security related metrics][culturemetrics]
 
@@ -57,11 +57,11 @@ management and development teams all working together - all are necessary for a 
 
 Security Champions are an important way of encouraging security within an organization - an organization can have a
 healthy security culture without security champions but it is a lot easier with a security champion program in place.
-Selecting and nurturing [security champions][culturechamps] has to be tailored to the individual organisation,
+Selecting and nurturing [security champions][culturechamps] has to be tailored to the individual organization,
 no security champion program will be the same as another one and close reference should be made to
 the [Security Champions Playbook][scplaybook].
 
-[Threat modelling][culturetm] is an activity that in itself is important within an organization,
+[Threat modeling][culturetm] is an activity that in itself is important within an organization,
 and it also has the benefit of helping communication between the security teams and development teams.
 [Security testing][culturetest] (such as [SAST][dsosast], [DAST][dsodast] and [IAST][dsoiast])
 is another area where close collaboration is required within the organization:

--- a/draft/10-culture-process/02-security-champions/01-security-champions-program.md
+++ b/draft/10-culture-process/02-security-champions/01-security-champions-program.md
@@ -43,11 +43,11 @@ and are seen as the first point of contact between developers and a central secu
 There is no universally defined role for a security champion, but the [Security Culture project][culturechamps]
 provides various suggestions:
 
-* Evangelise security: promoting security best practice in their team,
+* Evangelize security: promoting security best practice in their team,
     imparting security knowledge and helping to uplift security awareness in their team
-* Contribute to security standards: provide input into organisational security standards and procedures
+* Contribute to security standards: provide input into organizational security standards and procedures
 * Help run activities: promote activities such as Capture the Flag events or secure coding training
-* Oversee threat modelling: threat modelling consists of a security review on a product in the design phase
+* Oversee threat modeling: threat modeling consists of a security review on a product in the design phase
 * Oversee secure code reviews: raise issues of risk in the code base that arise from peer group code reviews
 * Use security testing tools: provide support to their team for the use of security testing tools
 
@@ -68,7 +68,7 @@ The OWASP [Security Champions Guide][scguide] identifies ten key principles for 
 * Be passionate about security - identify the members of the teams that show interest in security
 * Start with a clear vision for your program - be practical but ambitious, after if it works then it will work well
 * Secure management support - as always, going it alone without management support is never going to work
-* Nominate a dedicated captain - the program will take organisation and maintaining, so find someone willing to do that
+* Nominate a dedicated captain - the program will take organization and maintaining, so find someone willing to do that
 * Trust your champions - they are usually highly motivated when it comes to the security of their own applications
 * Create a community - it can be lonely, so provide a support network
 * Promote knowledge sharing - if the community is in place, then encourage discussions and meet-ups

--- a/draft/10-culture-process/04-asvs.md
+++ b/draft/10-culture-process/04-asvs.md
@@ -76,7 +76,7 @@ The appropriate ASVS level should be chosen from:
 * Level 2: Most applications
 * Level 3: High value, high assurance, or high safety
 
-This is not a judgemental ranking, for example if an application needs only Level 1 protection then that is a valid choice.
+This is not a judgmental ranking, for example if an application needs only Level 1 protection then that is a valid choice.
 Tools such as [SecurityRAT][srat] can then help create a subset of the ASVS security requirements for consideration.
 
 Application developer teams and application owners can then gain familiarity with the appropriate security

--- a/draft/14-appendices/01-implementation-dos-donts/01-container-security.md
+++ b/draft/14-appendices/01-implementation-dos-donts/01-container-security.md
@@ -42,7 +42,7 @@ Container image security, host security, client security, daemon security, runti
 * Use tagging keys associated with a registry.
     Such that a poisoned image from a different registry cannot be pushed into a registry.
 * Use offline keys to sign the tagging keys.
-* Offline keys are owned by the organisation and secured in an out-of-band location.
+* Offline keys are owned by the organization and secured in an out-of-band location.
 * Scan images frequently for any vulnerabilities. Rebuilt all images to include patches
     and instantiate new containers from them
 * Remove `setuid` and `setgid` permissions from the images.
@@ -54,7 +54,7 @@ Container image security, host security, client security, daemon security, runti
 * Mount files on a separate partition to address any situation where the mount becomes full,
     but the host still remains usable
 * Mark registries as private and only use signed images.
-* Pass commands through the authorization plugin to ensure that only authorised client connects to the daemon
+* Pass commands through the authorization plugin to ensure that only authorized client connects to the daemon
 * TLS authentication is configured to restrict access to the Docker daemon
 * Namespaces are enabled to ensure that
 * Leave control groups (cgroups) at default setting to ensure that tampering does not take place

--- a/draft/14-appendices/01-implementation-dos-donts/02-secure-coding.md
+++ b/draft/14-appendices/01-implementation-dos-donts/02-secure-coding.md
@@ -21,25 +21,25 @@ Some of these are language specific and others have more general applicability.
   * User
     * Require authentication for all pages and resources, except those specifically intended to be public
     * Perform all authentication on server side. Send credentials only on encrypted channel (HTTPS)
-    * Use a centralised implementation for all authentication controls, including libraries that call external
+    * Use a centralized implementation for all authentication controls, including libraries that call external
         authentication services. Use security vetted libraries for federation (Okta / PING / etc).
         If using third party code for authentication, inspect the code carefully to ensure it is not affected
         by any malicious code
     * Segregate authentication logic from the resource being requested and use redirection to and from
-        the centralised authentication control
+        the centralized authentication control
     * Validate the authentication data only on completion of all data input,
         especially for sequential authentication implementations
     * Authentication failure responses should not indicate which part of the authentication data was incorrect.
         For example, instead of "Invalid username" or "Invalid password",
         just use "Invalid username and/or password" for both.
         Error responses must be truly identical in both display and source code
-    * Utilise authentication for connections to external systems that involve sensitive information or functions
+    * Utilize authentication for connections to external systems that involve sensitive information or functions
     * Authentication credentials for accessing services external to the application should be encrypted
         and  stored in a protected location on a trusted system (e.g., Secrets Manager).
         The source code is NOT a secure location.
     * Do not store passwords in code or in configuration files. Use Secrets Manager to store passwords
     * Use only HTTP POST requests to transmit authentication credentials
-    * Implement monitoring to identify attacks against multiple user accounts, utilising the same password.
+    * Implement monitoring to identify attacks against multiple user accounts, utilizing the same password.
         This attack pattern is used to bypass standard lockouts, when user IDs can be harvested or guessed
     * Re-authenticate users prior to performing critical operations
     * Use Multi-Factor Authentication for highly sensitive or high value transactional accounts
@@ -51,7 +51,7 @@ Some of these are language specific and others have more general applicability.
     * Restrict authentication cookies to HTTPS connections
     * If the application has any design to persist passwords in the database, hash and salt the password
         before storing in database. Compare hashes to validate password
-    * Authenticate the user before authorising access to hidden directories
+    * Authenticate the user before authorizing access to hidden directories
     * Ensure registration, credential recovery, and API pathways are hardened against account enumeration attacks
         by using the same messages for all outcomes.
   * Server
@@ -105,41 +105,41 @@ Some of these are language specific and others have more general applicability.
         may require more frequent changes. The time between resets must be administratively controlled
     * Disable "remember me" functionality for password fields
     * Avoid sending authentication information through E-mail, particularly for existing users.
-* Authorisation
+* Authorization
   * Access control
-    * Build authorisation on rules based access control.
+    * Build authorization on rules based access control.
         Persist the rules as a matrix (for example as a list of strings which is passed as a parameter to a method
         that is run when the user first access the page, based on which access is granted).
         Most frameworks today, support this kind of matrix.
     * Check if the user is authenticated before checking the access matrix.
         If the user is not authenticated, direct the user to the login page.
-        Alternatively, use a single site-wide component to check access authorisation.
-        This includes libraries that call external authorisation services
+        Alternatively, use a single site-wide component to check access authorization.
+        This includes libraries that call external authorization services
     * Ensure that the application has clearly defined the user types and the privileges for the users.
     * Ensure there is a least privilege stance in operation. Add users to groups and assign privileges to groups
     * Scan the code for development/debug backdoors before deploying the code to production.
-    * Re-Authenticate the user before authorising the user to perform business critical activities
-    * Re-Authenticate the user before authorising the user to admin section of the application
-    * Do not include authorisation in the query string. Direct the user to the page via a hyperlink on a page.
+    * Re-Authenticate the user before authorizing the user to perform business critical activities
+    * Re-Authenticate the user before authorizing the user to admin section of the application
+    * Do not include authorization in the query string. Direct the user to the page via a hyperlink on a page.
         Authenticate the user before granting access. For example if `admin.php` is the admin page for `www.example.com`
         do not create a query string like `www.example.com/admin.php`.
-        Instead include a hyperlink to `admin.php` on a page and control authorisation to the page
+        Instead include a hyperlink to `admin.php` on a page and control authorization to the page
     * Prevent forced browsing with role based access control matrix
     * Ensure Lookup IDs are not accessible even when guessed and lookup IDs cannot be tampered with
-    * Enforce authorisation controls on every request, including those made by server side scripts,
+    * Enforce authorization controls on every request, including those made by server side scripts,
         "includes" and requests from rich client-side technologies like AJAX and Flash
     * Server side implementation and presentation layer representations of access control rules must match
     * Implement access controls for POST, PUT and DELETE especially when building an API
-    * Use the "referer" header as a supplemental check only, it should never be the sole authorisation check,
+    * Use the "referer" header as a supplemental check only, it should never be the sole authorization check,
         as it is can be spoofed
-    * Ensure it is not possible to access sensitive URLs without proper authorisation.
+    * Ensure it is not possible to access sensitive URLs without proper authorization.
         Resources like images, videos should not be accessed directly by simply specifying the correct path
-    * Test all URLs on administrator pages to ensure that authorisation requirements are met.
+    * Test all URLs on administrator pages to ensure that authorization requirements are met.
         If verbs are sent cross domain, pin the OPTIONS request for non-GET verbs to the IP address of
         subsequent requests. This will be a first step toward mitigating DNS Rebinding and TOCTOU attacks.
   * Session management
     * Creation of session: Use the server or framework’s session management controls.
-        The application should only recognise these session identifiers as valid
+        The application should only recognize these session identifiers as valid
     * Creation of session: Session identifier creation must always be done on a trusted system (e.g., The server)
     * Creation of session: If a session was established before login,
         close that session and establish a new session after a successful login
@@ -157,7 +157,7 @@ Some of these are language specific and others have more general applicability.
         Session identifiers should only be located in the HTTP cookie header. For example,
         do not pass session identifiers as GET parameters
     * Session ID: Supplement standard session management for sensitive server-side operations, like account management,
-        by utilising per-session strong random tokens or parameters.
+        by utilizing per-session strong random tokens or parameters.
         This method can be used to prevent Cross Site Request Forgery attacks
   * JWT
     * Reject tokens set with ‘none’ algorithm when a private key was used to issue them (`alg: ""none""`).
@@ -181,11 +181,11 @@ Some of these are language specific and others have more general applicability.
     * Always check that the `aud` field of the JWT matches the expected value,
         usually the domain or the URL of your APIs. If possible, check the "sub" (client ID) - make sure that
         this is a known client. This may not be feasible however in a public API situation
-        (e.g., we trust all clients authorised by Google).
-    * Validate the issuer's URL (`iss`) of the token. It must match your authorisation server.
-    * If an authorisation server provides X509 certificates as part of its JWT,
+        (e.g., we trust all clients authorized by Google).
+    * Validate the issuer's URL (`iss`) of the token. It must match your authorization server.
+    * If an authorization server provides X509 certificates as part of its JWT,
         validate the public key using a regular PKIX mechanism
-    * Make sure that the keys are frequently refreshed/rotated by the authorisation server.
+    * Make sure that the keys are frequently refreshed/rotated by the authorization server.
     * Make sure that the algorithms you use are sanctioned by JWA ([RFC7518][rfc7518])
     * There is no built in mechanism to revoke a token manually, before it expires.
         One way to ensure that the token is force expired build a service that can be called on log out.
@@ -208,7 +208,7 @@ Some of these are language specific and others have more general applicability.
       These layers are usually in the form of a library or a package. Ensure to add
       these libraries  / dependencies / packages to the project file such that they are not missed out.
   * Use a security vetted library for input data validation. Try not to use hard coded allow-list of characters.
-      Validate all data from a centralised function / routine.
+      Validate all data from a centralized function / routine.
       In order to add a variable to a HTML context safely, use HTML entity encoding
       for that variable as you add it to a web template.
     * Validate HTTP headers. Dependencies that perform HTTP headers validation are available in technologies.
@@ -228,14 +228,14 @@ Some of these are language specific and others have more general applicability.
       * Check for “dot-dot-slash" `../` or `..\` path alterations characters.
           In cases where UTF-8 extended character set encoding is supported, address alternate representation like:
           `%c0%ae%c0%ae/`
-          (Utilise canonicalization to address double encoding or other forms of obfuscation attacks)
+          (Utilize canonicalization to address double encoding or other forms of obfuscation attacks)
     * Client-side storage (`localStorage`, `SessionStorage`, `IndexedDB`, WebSQL):
         If you use client-side storage for persistence of any variables,
         validate the date before consuming it in the application
     * Reject all input data that has failed validation.
     * If used, don’t involve user parameters in calculating the destination. This can usually be done.
         If destination parameters can’t be avoided, ensure that the supplied value is valid,
-        and authorised for the user.
+        and authorized for the user.
         It is recommended that any such destination parameters be a mapping value,
         rather than the actual URL or portion of the URL,
         and that server side code translate this mapping to the target URL.
@@ -252,13 +252,13 @@ Some of these are language specific and others have more general applicability.
       Use quotation marks like " or ' to surround your variables.
       Quoting makes it difficult to change the context a variable operates in, which helps prevent XSS
   * Conduct all encoding on a trusted system (e.g., The server)
-      Utilise a standard, tested routine for each type of outbound encoding
+      Utilize a standard, tested routine for each type of outbound encoding
       Contextually output encode all data returned to the client
       that originated outside the application's trust boundary.
       HTML entity encoding is one example, but does not work in all cases
       Encode all characters unless they are known to be safe for the intended interpreter
-      Contextually sanitise all output of untrusted data to queries for SQL, XML, and LDAP
-      Sanitise all output of untrusted data to operating system commands
+      Contextually sanitize all output of untrusted data to queries for SQL, XML, and LDAP
+      Sanitize all output of untrusted data to operating system commands
   * Output encoding is not always perfect. It will not always prevent XSS. Some contexts are not secure. These include:
       Callback functions
       Where URLs are handled in code such as this CSS `{ background-url : “javascript:alert(test)”; }`
@@ -284,8 +284,8 @@ Some of these are language specific and others have more general applicability.
     Be careful that this doesn't introduce an enumeration vulnerability where
     a user could cycle through IDs to find all possible redirect targets
     If user input can’t be avoided, ensure that the supplied value is valid, appropriate for the application,
-    and is authorised for the user.
-    Sanitise input by creating a list of trusted URLs (lists of hosts or a regex).
+    and is authorized for the user.
+    Sanitize input by creating a list of trusted URLs (lists of hosts or a regex).
     This should be based on an allow-list approach, rather than a block list.
     Force all redirects to first go through a page notifying users that they are going off of your site,
     with the destination clearly displayed, and have them click a link to confirm.
@@ -299,11 +299,11 @@ Some of these are language specific and others have more general applicability.
     Truncating may break sanitization routines for multi-parser applications."
 * Produce errors when handling integers or floating-point numbers that cannot be represented faithfully
 * Do not use `eval()` with JSON. This opens up for JSON injection attacks. Use JSON.parse() instead
-    Data from an untrusted source is not sanitised by the server and written directly to a JSON stream.
+    Data from an untrusted source is not sanitized by the server and written directly to a JSON stream.
     This is referred to as server-side JSON injection.
-    Data from an untrusted source is not sanitised and parsed directly using the JavaScript `eval` function.
+    Data from an untrusted source is not sanitized and parsed directly using the JavaScript `eval` function.
     This is referred to as client-side JSON injection.
-    To prevent server-side JSON injections, sanitise all data before serialising it to JSON
+    To prevent server-side JSON injections, sanitize all data before serializing it to JSON
     Escape characters like ":", "\", "@", "'”", "%", "?", "--", ">", "<", "&"
 
 #### JSON Vulnerability Protection

--- a/draft/14-appendices/01-implementation-dos-donts/03-cryptographic-practices.md
+++ b/draft/14-appendices/01-implementation-dos-donts/03-cryptographic-practices.md
@@ -28,7 +28,7 @@ Here is a collection of Do's and Don'ts when it comes to cryptographic practices
 * Do not hard-code cryptographic keys in the application
 * Persist secret keys in a secure vault like HSM, KMS, Secrets Manager
 * Manage encryption keys through the lifecycle, including key retirement/replacement
-    when someone who has access leaves the organisation
+    when someone who has access leaves the organization
 * Rotate keys on a regular basis. However this depends on the key strength and the algorithm used.
     If the key strength is low, the rotation period will be smaller
 * Maintain a contingency plan to recover data in the event of an encrypted key being lost
@@ -49,7 +49,7 @@ Here is a collection of Do's and Don'ts when it comes to cryptographic practices
 * Do not use custom cryptographic algorithms that have not been vetted by cryptography community
 * Do not hardcode cryptographic keys in applications?
 * Issue keys using a secure means.
-* Maintain a key lifecycle for the organisation (Creation, Storage, Distribution and installation, Use,
+* Maintain a key lifecycle for the organization (Creation, Storage, Distribution and installation, Use,
     Rotation, Backup, Recovery, Revocation, Suspension, Destruction)
 * Lock and unlock symmetric secret keys securely
 * Maintain CRL (Certificate Revocation Lists) maintained on a real-time basis

--- a/draft/14-appendices/02-verification-dos-donts/03-open-source-software.md
+++ b/draft/14-appendices/02-verification-dos-donts/03-open-source-software.md
@@ -25,11 +25,11 @@ Some of these are language specific and others have more general applicability.
     * `https://tldrlegal.com/`
     * `https://creativecommons.org/licenses/by/4.0/`
 
-It is important for the organisation to have a policy statement for consumption of open source software.
+It is important for the organization to have a policy statement for consumption of open source software.
 From a licensing perspective and the implication of using a open source software incorrectly,
 maintain a procedure for approval of usage of selected open source software.
 This could be in the form of a workflow or obtaining security approvals for the chosen open source software
-We realise it could be challenging, but if feasible, maintain a list of approved open source software
+We realize it could be challenging, but if feasible, maintain a list of approved open source software
 
 * Address vulnerabilities with: Binaries / pre-compiled code / packages
     where source code sharing is not a part of the license (Examples executables / NuGets)
@@ -38,7 +38,7 @@ We realise it could be challenging, but if feasible, maintain a list of approved
   * Check for vulnerabilities for the selected binaries in vulnerability disclosure databases like
     * CVE database (`https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=bouncy+castle`)
     * VulnDB (`https://vuldb.com/?id.173918`)
-  * If within the budget of your organisation, use an SCA tool to scan for vulnerabilities
+  * If within the budget of your organization, use an SCA tool to scan for vulnerabilities
   * Always vet and perform due-diligence on third-party modules that you install
       in order to confirm their health and credibility.
   * Hold-off on upgrading immediately to new versions; allow new package versions some time to circulate
@@ -55,7 +55,7 @@ We realise it could be challenging, but if feasible, maintain a list of approved
 
 * Address vulnerabilities with: where source code sharing is a part of the license
   * GitHub CodeQL / third party tool
-  * If within the budget of your organisation, use an SCA tool to scan for vulnerabilities
+  * If within the budget of your organization, use an SCA tool to scan for vulnerabilities
 
 * Security Testing: Binaries / pre-compiled code / packages
     where source code sharing is not a part of the license (Examples executables / NuGets)
@@ -102,7 +102,7 @@ We realise it could be challenging, but if feasible, maintain a list of approved
     * Check for vulnerabilities for the selected binaries in vulnerability disclosure databases like
       * CVE database (`https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=bouncy+castle`)
       * VulnDB (`https://vuldb.com/?id.173918`)
-  * If within the budget of your organisation, use an SCA tool to scan for vulnerabilities
+  * If within the budget of your organization, use an SCA tool to scan for vulnerabilities
 
 * Copying source code off public domain (internet)
     For example source code that is on a blog or in discussion forums like stacktrace or snippets of example on writeups


### PR DESCRIPTION
**Summary** :  
changes spelling throughout document to use dialect EN-US rather than a mixture from dialect EN-GB

**Description for the changelog** :  
use EN-US consistently throughout document

**Other info** :  
closes #318 
