### PR TITLE
PT-BR spellcheck calls pyspelling direct

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,13 +82,22 @@ jobs:
       - name: Checkout markdown
         uses: actions/checkout@v4.2.0
 
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v5.3.0
+        with:
+          python-version: '3.7'
+
+      - name: Install pyspelling
+        run: |
+          python -m pip install --upgrade pip setuptools
+          python -m pip install pyspelling
+          sudo apt-get install aspell aspell-pt
+
       - name: Spell check PT-BR release
         # disabled for now, until translation has less English in it
         if: false
-        uses: rojopolis/spellcheck-github-actions@0.45.0
-        with:
-          config_path: .spellcheck-pt-br.yaml
-          # checks the release-pt-br directory with a pt_BR dictionary
+        run: |
+          python -m pyspelling --config .spellcheck-pt-br.yaml
 
       - name: Lint PT-BR markdown
         uses: DavidAnson/markdownlint-cli2-action@v19.0.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,10 +82,10 @@ jobs:
       - name: Checkout markdown
         uses: actions/checkout@v4.2.0
 
-      - name: Set up Python 3.7
+      - name: Set up Python
         uses: actions/setup-python@v5.3.0
         with:
-          python-version: '3.7'
+          python-version: '3.10'
 
       - name: Install pyspelling
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -86,10 +86,10 @@ jobs:
       - name: Checkout markdown
         uses: actions/checkout@v4.2.0
 
-      - name: Set up Python 3.7
+      - name: Set up Python
         uses: actions/setup-python@v5.3.0
         with:
-          python-version: '3.7'
+          python-version: '3.10'
 
       - name: Install pyspelling
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -86,13 +86,22 @@ jobs:
       - name: Checkout markdown
         uses: actions/checkout@v4.2.0
 
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v5.3.0
+        with:
+          python-version: '3.7'
+
+      - name: Install pyspelling
+        run: |
+          python -m pip install --upgrade pip setuptools
+          python -m pip install pyspelling
+          sudo apt-get install aspell aspell-pt
+
       - name: Spell check PT-BR release
         # disabled for now, until translation has less English in it
         if: false
-        uses: rojopolis/spellcheck-github-actions@0.45.0
-        with:
-          config_path: .spellcheck-pt-br.yaml
-          # checks the release-pt-br directory with a pt_BR dictionary
+        run: |
+          python -m pyspelling --config .spellcheck-pt-br.yaml
 
       - name: Lint PT-BR markdown
         uses: DavidAnson/markdownlint-cli2-action@v19.0.0

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,10 +86,10 @@ jobs:
       - name: Checkout markdown
         uses: actions/checkout@v4.2.0
 
-      - name: Set up Python 3.7
+      - name: Set up Python
         uses: actions/setup-python@v5.3.0
         with:
-          python-version: '3.7'
+          python-version: '3.10'
 
       - name: Install pyspelling
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -86,13 +86,22 @@ jobs:
       - name: Checkout markdown
         uses: actions/checkout@v4.2.0
 
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v5.3.0
+        with:
+          python-version: '3.7'
+
+      - name: Install pyspelling
+        run: |
+          python -m pip install --upgrade pip setuptools
+          python -m pip install pyspelling
+          sudo apt-get install aspell aspell-pt
+
       - name: Spell check PT-BR release
         # disabled for now, until translation has less English in it
         if: false
-        uses: rojopolis/spellcheck-github-actions@0.45.0
-        with:
-          config_path: .spellcheck-pt-br.yaml
-          # checks the release-pt-br directory with a pt_BR dictionary
+        run: |
+          python -m pyspelling --config .spellcheck-pt-br.yaml
 
       - name: Lint PT-BR markdown
         uses: DavidAnson/markdownlint-cli2-action@v19.0.0

--- a/.spellcheck-pt-br.yaml
+++ b/.spellcheck-pt-br.yaml
@@ -1,8 +1,7 @@
 matrix:
 - name: Markdown
   aspell:
-    lang: pt
-    d: pt_BR
+    lang: pt_BR
   dictionary:
     wordlists:
     - .wordlist-pt-br.txt


### PR DESCRIPTION
**Summary** :  
the github action `rojopolis/spellcheck-github-actions` does not support Portuguese, so `pyspelling` has to be installed and called direct

**Description for the changelog** :  
use pyspelling direct for PT-BR spellcheck

**Other info** :  

