### PR TITLE
#240 Translate Developer Guide to Hindi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,63 +1,63 @@
-<img src="assets/images/dg_logo_di.png" alt="DevGuide logo" height="220px"/>
+<img src="assets/images/dg_logo_di.png" alt="डेवगाइड लोगो" height="220px"/>
 
-[![Build status](https://github.com/OWASP/www-project-developer-guide/actions/workflows/ci.yaml/badge.svg?event=push)][build]
-[![GitHub license](https://img.shields.io/github/license/owasp/www-project-developer-guide.svg)](license.txt)
-[![OWASP Lab project](https://img.shields.io/badge/owasp-lab%20project-f7b73c.svg)](https://www.owasp.org/projects)
-[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9373/badge)](https://www.bestpractices.dev/projects/9373)
+[![बिल्ड स्थिति](https://github.com/OWASP/www-project-developer-guide/actions/workflows/ci.yaml/badge.svg?event=push)][build]
+[![GitHub लाइसेंस](https://img.shields.io/github/license/owasp/www-project-developer-guide.svg)](license.txt)
+[![OWASP लैब प्रोजेक्ट](https://img.shields.io/badge/owasp-lab%20project-f7b73c.svg)](https://www.owasp.org/projects)
+[![OpenSSF सर्वश्रेष्ठ प्रथाएँ](https://www.bestpractices.dev/projects/9373/badge)](https://www.bestpractices.dev/projects/9373)
 
-## OWASP Foundation Developer Guide project
+## OWASP फाउंडेशन डेवलपर गाइड प्रोजेक्ट
 
-This repo is the source for the OWASP Developer Guide project [web pages][pages]
-and also the [developer guide][dgrelease] itself.
+यह रेपो OWASP डेवलपर गाइड प्रोजेक्ट [वेब पेज][pages] और [डेवलपर गाइड][dgrelease] का स्रोत है।
 
-## Developer Guide
+## डेवलपर गाइड
 
-This guide is one of the original documents from OWASP and so has a long history.
-The [original DevGuide repository][devguide] has many of the [previous versions][versions]
-going back to the [original version 1.0][original] from 2002.
-Note that the original DevGuide repository has been deprecated in favor of this one.
+यह गाइड OWASP के मूल दस्तावेज़ों में से एक है और इसका एक लंबा इतिहास है।  
+[मूल DevGuide रिपोजिटरी][devguide] में [पिछले संस्करणों][versions] का संग्रह है, जिसमें [मूल संस्करण 1.0][original] शामिल है, जो 2002 में प्रकाशित हुआ था।  
+ध्यान दें कि मूल DevGuide रिपोजिटरी को इस नई रिपोजिटरी से बदल दिया गया है।
 
-The source for the latest draft developer guide can be found under the ['draft'][draft] directory.
-The source is in markdown and is used to create the developer guide HTML, PDF and ePub outputs.
-The draft content is subject to large scale changes with no notice.
+नवीनतम ड्राफ्ट डेवलपर गाइड का स्रोत ['draft'][draft] निर्देशिका में पाया जा सकता है।  
+स्रोत मार्कडाउन में है और इसका उपयोग HTML, PDF और ePub आउटपुट बनाने के लिए किया जाता है।  
+ड्राफ्ट सामग्री बिना किसी सूचना के बड़े बदलाव के अधीन हो सकती है।
 
-Note that the draft version provides the content for the released version of Developer Guide,
-in the ['release'][release] directory, promoted during the automated release process.
-Therefore any manual changes under the release directory are likely to be over-written.
+ड्राफ्ट संस्करण, स्वचालित रिलीज प्रक्रिया के दौरान, ['release'][release] निर्देशिका में डेवलपर गाइड के प्रकाशित संस्करण के लिए सामग्री प्रदान करता है।  
+**इसलिए, रिलीज़ निर्देशिका में कोई भी मैन्युअल परिवर्तन ओवर-राइट होने की संभावना है।**
 
-### Contributing
+---
 
-Contributions and suggestions for the Developer Guide are all welcome;
-make a start by reading the [contributing guidelines][guide] and follow the [contributing code of conduct][conduct].
+### योगदान
 
-For other contributions to these pages please [create an issue][issues] or open a [pull request][request].
+डेवलपर गाइड के लिए सुझाव और योगदान का स्वागत है।  
+[योगदान दिशानिर्देश][guide] पढ़कर और [आचार संहिता][conduct] का पालन करके शुरुआत करें।
 
-The easiest way to get in contact with the development community for this documentation project
-is via the OWASP Slack [#project-developer-guide][project] project channel
-(you may need to [subscribe](https://owasp.org/slack/invite) first).
+इन पृष्ठों के लिए अन्य योगदानों के लिए, कृपया [समस्या बनाएं][issues] या [पुल अनुरोध खोलें][request]।  
 
-### Project leaders / editors
+इस प्रोजेक्ट के विकास समुदाय से संपर्क करने का सबसे आसान तरीका OWASP Slack पर [#project-developer-guide][project] चैनल के माध्यम से है।  
+(आपको पहले [सदस्यता लेना](https://owasp.org/slack/invite) पड़ सकता है।)
 
-- [Andra Lezza](mailto:andra.lezza@owasp.org)
-- [Shruti Kulkarni](mailto:shruti.kulkarni@owasp.org)
-- [Vandana Verma](vandana.verma@owasp.org)
-- [Harold Blankenship](mailto:harold.blankenship@owasp.org)
-- [Jon Gadsden](mailto:jon.gadsden@owasp.org)
+---
 
-----
+### प्रोजेक्ट लीडर्स / संपादक
 
-OWASP Developer Guide: _accessible security for developers_
+- [आंद्रा लेज़ा](mailto:andra.lezza@owasp.org)  
+- [श्रुति कुलकर्णी](mailto:shruti.kulkarni@owasp.org)  
+- [वंदना वर्मा](mailto:vandana.verma@owasp.org)  
+- [हेरोल्ड ब्लैंकेंशिप](mailto:harold.blankenship@owasp.org)  
+- [जॉन गैड्सडेन](mailto:jon.gadsden@owasp.org)  
 
-[build]: https://github.com/OWASP/www-project-developer-guide/actions/workflows/ci.yaml
-[conduct]: code_of_conduct.md
-[devguide]: https://github.com/OWASP/DevGuide
-[draft]: draft
-[dgrelease]: https://owasp.org/www-project-developer-guide/release/
-[guide]: contributing.md
-[issues]: https://github.com/OWASP/www-project-developer-guide/issues/new/choose
-[original]: https://github.com/OWASP/DevGuide/blob/1d24d140de3724b6f95655e53b8d0cc6689fbfd8/DevGuide1.0/OWASPBuildingSecureWebApplicationsAndWebServices-V1.0.pdf
-[pages]: https://owasp.org/www-project-developer-guide/
-[project]: https://owasp.slack.com/messages/C04QN6CMNAC
-[release]: release
-[request]: https://github.com/OWASP/www-project-developer-guide/pulls
+---
+
+OWASP डेवलपर गाइड: _डेवलपर्स के लिए सुलभ सुरक्षा_
+
+[build]: https://github.com/OWASP/www-project-developer-guide/actions/workflows/ci.yaml  
+[conduct]: code_of_conduct.md  
+[devguide]: https://github.com/OWASP/DevGuide  
+[draft]: draft  
+[dgrelease]: https://owasp.org/www-project-developer-guide/release/  
+[guide]: contributing.md  
+[issues]: https://github.com/OWASP/www-project-developer-guide/issues/new/choose  
+[original]: https://github.com/OWASP/DevGuide/blob/1d24d140de3724b6f95655e53b8d0cc6689fbfd8/DevGuide1.0/OWASPBuildingSecureWebApplicationsAndWebServices-V1.0.pdf  
+[pages]: https://owasp.org/www-project-developer-guide/  
+[project]: https://owasp.slack.com/messages/C04QN6CMNAC  
+[release]: release  
+[request]: https://github.com/OWASP/www-project-developer-guide/pulls  
 [versions]: https://github.com/OWASP/DevGuide/wiki#old-versions


### PR DESCRIPTION
The Developer Guide needs to be translated into Hindi to expand its reach among Hindi-speaking developers. This effort will include translating all sections of the guide, ensuring accuracy and consistency with the original content.