### PR TITLE
Fix WIP logo not found error for pt-br pages

### DIFF
--- a/release-pt-br/05-requirements/00-toc.md
+++ b/release-pt-br/05-requirements/00-toc.md
@@ -12,7 +12,7 @@ permalink:
 
 {% include breadcrumb.html %}
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){height=180px}
+![WIP logo](../../assets/images/dg_wip.png "Trabalho em andamento"){height=180px}
 
 ## 3. Requisitos
 

--- a/release-pt-br/05-requirements/toc.md
+++ b/release-pt-br/05-requirements/toc.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/requisitos/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ## 3. Requisitos
 

--- a/release-pt-br/06-design/00-toc.md
+++ b/release-pt-br/06-design/00-toc.md
@@ -11,7 +11,7 @@ order:
 
 {% include breadcrumb.html %}
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){height=180px}
+![WIP logo](../../assets/images/dg_wip.png "Trabalho em andamento"){height=180px}
 
 ## 4. Design
 

--- a/release-pt-br/06-design/01-threat-modeling/01-threat-modeling.md
+++ b/release-pt-br/06-design/01-threat-modeling/01-threat-modeling.md
@@ -6,7 +6,7 @@ tags: Guia do Desenvolvedor do OWASP
 contributors:
 document: Guia do Desenvolvedor do OWASP
 order: 26110
-permalink: /release-pt-br/design/modelagem_ameaças/prática
+permalink: /release-pt-br/design/modelagem_ameaças/prática/
 
 ---
 
@@ -22,7 +22,7 @@ permalink: /release-pt-br/design/modelagem_ameaças/prática
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 4.1.1 Modelagem de ameaças em prática
 

--- a/release-pt-br/06-design/01-threat-modeling/02-pytm.md
+++ b/release-pt-br/06-design/01-threat-modeling/02-pytm.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/design/modelagem_ameaças/pytm/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 4.1.2 pytm
 

--- a/release-pt-br/06-design/01-threat-modeling/03-threat-dragon.md
+++ b/release-pt-br/06-design/01-threat-modeling/03-threat-dragon.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/design/modelagem_ameaças/threat_dragon/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 4.1.3 Threat Dragon
 

--- a/release-pt-br/06-design/01-threat-modeling/04-cornucopia.md
+++ b/release-pt-br/06-design/01-threat-modeling/04-cornucopia.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/design/modelagem_ameaças/cornucopia/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 4.1.4 Cornucopia
 

--- a/release-pt-br/06-design/01-threat-modeling/05-linddun-go.md
+++ b/release-pt-br/06-design/01-threat-modeling/05-linddun-go.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/design/modelagem_ameaças/linddun-go/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 4.1.5 LINDDUN GO
 

--- a/release-pt-br/06-design/01-threat-modeling/06-toolkit.md
+++ b/release-pt-br/06-design/01-threat-modeling/06-toolkit.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/design/modelagem_ameaças/toolkit/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 4.1.6 Toolkit para Modelagem de Ameaças
 

--- a/release-pt-br/06-design/02-web-app-checklist/01-define-security-requirements.md
+++ b/release-pt-br/06-design/02-web-app-checklist/01-define-security-requirements.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/design/lista_verificação_web/defina_requisitos_segur
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 4.2.1 Defina Requisitos de Segurança
 

--- a/release-pt-br/06-design/02-web-app-checklist/02-frameworks-libraries.md
+++ b/release-pt-br/06-design/02-web-app-checklist/02-frameworks-libraries.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/design/lista_verificação_web/frameworks_bibliotecas/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 4.2.2 Utilize Frameworks e Bibliotecas de Segurança
 

--- a/release-pt-br/06-design/02-web-app-checklist/03-secure-database-access.md
+++ b/release-pt-br/06-design/02-web-app-checklist/03-secure-database-access.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/design/lista_verificação_web/proteja_acesso_banco_da
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 4.2.3 Proteja Acesso ao Banco de Dados
 

--- a/release-pt-br/06-design/02-web-app-checklist/04-encode-escape-data.md
+++ b/release-pt-br/06-design/02-web-app-checklist/04-encode-escape-data.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/design/lista_verificação_web/codifique_escape_dados/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 4.2.4 Codifique e Escape Dados
 

--- a/release-pt-br/06-design/02-web-app-checklist/05-validate-inputs.md
+++ b/release-pt-br/06-design/02-web-app-checklist/05-validate-inputs.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/design/lista_verificação_web/valide_entradas/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 4.2.5 Valide todas as entradas
 

--- a/release-pt-br/06-design/02-web-app-checklist/06-digital-identity.md
+++ b/release-pt-br/06-design/02-web-app-checklist/06-digital-identity.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/design/lista_verificação_web/implemente_identidade_d
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 4.2.6 Implemente Identidade Digital
 

--- a/release-pt-br/06-design/02-web-app-checklist/07-access-controls.md
+++ b/release-pt-br/06-design/02-web-app-checklist/07-access-controls.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/design/lista_verificação_web/imponha_controles_acess
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 4.2.7 Imponha Controles de Acesso
 

--- a/release-pt-br/06-design/02-web-app-checklist/08-protect-data.md
+++ b/release-pt-br/06-design/02-web-app-checklist/08-protect-data.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/design/lista_verificação_web/proteja_dados/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 4.2.8 Proteja Dados em Todos os Lugares
 

--- a/release-pt-br/06-design/02-web-app-checklist/09-logging-monitoring.md
+++ b/release-pt-br/06-design/02-web-app-checklist/09-logging-monitoring.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/design/lista_verificação_web/registro_monitoramento_
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 4.2.9 Implemente Registro e Monitoramento de Segurança
 

--- a/release-pt-br/06-design/02-web-app-checklist/10-handle-errors-exceptions.md
+++ b/release-pt-br/06-design/02-web-app-checklist/10-handle-errors-exceptions.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/design/lista_verificação_web/trate_todos_errors_exce
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 4.2.10 Trate todos os Errors e Exceções
 

--- a/release-pt-br/06-design/toc.md
+++ b/release-pt-br/06-design/toc.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/design/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ## 4. Design
 

--- a/release-pt-br/07-implementation/00-toc.md
+++ b/release-pt-br/07-implementation/00-toc.md
@@ -11,7 +11,7 @@ order:
 
 {% include breadcrumb.html %}
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){height=180px}
+![WIP logo](../../assets/images/dg_wip.png "Trabalho em andamento"){height=180px}
 
 ## 5. Implementação
 

--- a/release-pt-br/07-implementation/01-documentation/01-proactive-controls.md
+++ b/release-pt-br/07-implementation/01-documentation/01-proactive-controls.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/implementação/documentação/controles_proativos/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 5.1.1 Top 10 Controles Proativos
 

--- a/release-pt-br/07-implementation/01-documentation/02-go-scp.md
+++ b/release-pt-br/07-implementation/01-documentation/02-go-scp.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/implementação/documentação/go_scp/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 5.1.2 GoSCP (Práticas de Codificação Segura em Go)
 

--- a/release-pt-br/07-implementation/01-documentation/03-cheatsheets.md
+++ b/release-pt-br/07-implementation/01-documentation/03-cheatsheets.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/implementação/documentação/série_folha_dicas/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 5.1.3 Série de Cheatsheet
 

--- a/release-pt-br/07-implementation/02-dependencies/01-dependency-check.md
+++ b/release-pt-br/07-implementation/02-dependencies/01-dependency-check.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/implementação/dependências/dependency_check/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 5.2.1 Dependency-Check
 

--- a/release-pt-br/07-implementation/02-dependencies/02-dependency-track.md
+++ b/release-pt-br/07-implementation/02-dependencies/02-dependency-track.md
@@ -12,6 +12,18 @@ permalink: /release-pt-br/implementação/dependências/dependency_track/
 
 {% include breadcrumb.html %}
 
+<style type="text/css">
+.image-right {
+  height: 180px;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+  float: right;
+}
+</style>
+
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+
 ### 5.2.2 Dependency-Track
 
 Não há tradução para esta página, consulte a [versão original em inglês][release070202].

--- a/release-pt-br/07-implementation/02-dependencies/03-cyclonedx.md
+++ b/release-pt-br/07-implementation/02-dependencies/03-cyclonedx.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/implementação/dependências/cyclonedx/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 5.2.3 CycloneDX
 

--- a/release-pt-br/07-implementation/03-secure-libraries/01-esapi.md
+++ b/release-pt-br/07-implementation/03-secure-libraries/01-esapi.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/implementação/bibliotecas_seguras/esapi/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 5.3.1 ESAPI (Biblioteca de API de Segurança Corporative)
 

--- a/release-pt-br/07-implementation/03-secure-libraries/02-csrf-guard.md
+++ b/release-pt-br/07-implementation/03-secure-libraries/02-csrf-guard.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/implementação/bibliotecas_seguras/csrfguard/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 5.3.2 CSRFGuard
 

--- a/release-pt-br/07-implementation/03-secure-libraries/03-secure-headers.md
+++ b/release-pt-br/07-implementation/03-secure-libraries/03-secure-headers.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/implementação/bibliotecas_seguras/oshp/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 5.3.3 OSHP
 

--- a/release-pt-br/07-implementation/toc.md
+++ b/release-pt-br/07-implementation/toc.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/implementação/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ## 5. Implementação
 

--- a/release-pt-br/08-verification/00-toc.md
+++ b/release-pt-br/08-verification/00-toc.md
@@ -11,7 +11,7 @@ order:
 
 {% include breadcrumb.html %}
 
-![Developer guide logo](../../assets/images/dg_logo.png "OWASP Developer Guide"){height=180px}
+![WIP logo](../../assets/images/dg_wip.png "Trabalho em andamento"){height=180px}
 
 ## 6. Verificação
 

--- a/release-pt-br/08-verification/01-guides/01-wstg.md
+++ b/release-pt-br/08-verification/01-guides/01-wstg.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/verificação/guias/wstg/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 6.1.1 WSTG
 

--- a/release-pt-br/08-verification/01-guides/02-mastg.md
+++ b/release-pt-br/08-verification/01-guides/02-mastg.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/verificação/guias/mastg/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 6.1.2 MASTG
 

--- a/release-pt-br/08-verification/01-guides/03-asvs.md
+++ b/release-pt-br/08-verification/01-guides/03-asvs.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/verificação/guias/asvs/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 6.1.3 ASVS verificação
 

--- a/release-pt-br/08-verification/02-tools/01-dast.md
+++ b/release-pt-br/08-verification/02-tools/01-dast.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/verificação/ferramentas/dast/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 6.2.1 Ferramentas DAST
 

--- a/release-pt-br/08-verification/02-tools/02-amass.md
+++ b/release-pt-br/08-verification/02-tools/02-amass.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/verificação/ferramentas/amass/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 6.2.2 Amass
 

--- a/release-pt-br/08-verification/02-tools/03-owtf.md
+++ b/release-pt-br/08-verification/02-tools/03-owtf.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/verificação/ferramentas/owtf/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 6.2.3 OWTF
 

--- a/release-pt-br/08-verification/02-tools/04-nettacker.md
+++ b/release-pt-br/08-verification/02-tools/04-nettacker.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/verificação/ferramentas/nettacker/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 6.2.4 Nettacker
 

--- a/release-pt-br/08-verification/02-tools/05-secure-headers.md
+++ b/release-pt-br/08-verification/02-tools/05-secure-headers.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/verificação/ferramentas/oshp/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 6.2.5 OSHP verificação
 

--- a/release-pt-br/08-verification/03-frameworks/01-secure-codebox.md
+++ b/release-pt-br/08-verification/03-frameworks/01-secure-codebox.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/verificação/frameworks/secure_codebox/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 #### 6.3.1 secureCodeBox
 

--- a/release-pt-br/08-verification/04-vulnerability-management/01-defectdojo.md
+++ b/release-pt-br/08-verification/04-vulnerability-management/01-defectdojo.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/verificação/gerenciamento_vulnerabilidades/defectdoj
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 6.4.1 DefectDojo
 

--- a/release-pt-br/08-verification/toc.md
+++ b/release-pt-br/08-verification/toc.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/verificação/
 }
 </style>
 
-![Developer guide logo](../../assets/images/dg_logo.png "OWASP Developer Guide"){: .image-right }
+![WIP logo](../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ## 6. Verificação
 

--- a/release-pt-br/09-training-education/00-toc.md
+++ b/release-pt-br/09-training-education/00-toc.md
@@ -11,7 +11,7 @@ order:
 
 {% include breadcrumb.html %}
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){height=180px}
+![WIP logo](../../assets/images/dg_wip.png "Trabalho em andamento"){height=180px}
 
 ## 7. Treinamento e Educação
 

--- a/release-pt-br/09-training-education/01-vulnerable-apps/01-juice-shop.md
+++ b/release-pt-br/09-training-education/01-vulnerable-apps/01-juice-shop.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/treinamento_educação/aplicações_vulneráveis/juice
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 7.1.1 Juice Shop
 

--- a/release-pt-br/09-training-education/01-vulnerable-apps/02-webgoat.md
+++ b/release-pt-br/09-training-education/01-vulnerable-apps/02-webgoat.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/treinamento_educação/aplicações_vulneráveis/webgo
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 7.1.2 WebGoat
 

--- a/release-pt-br/09-training-education/01-vulnerable-apps/03-pygoat.md
+++ b/release-pt-br/09-training-education/01-vulnerable-apps/03-pygoat.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/treinamento_educação/aplicações_vulneráveis/pygoa
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 7.1.3 PyGoat
 

--- a/release-pt-br/09-training-education/01-vulnerable-apps/04-security-shepherd.md
+++ b/release-pt-br/09-training-education/01-vulnerable-apps/04-security-shepherd.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/treinamento_educação/aplicações_vulneráveis/secur
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 7.1.4 Security Shepherd
 

--- a/release-pt-br/09-training-education/toc.md
+++ b/release-pt-br/09-training-education/toc.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/treinamento_educação/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ## 7. Treinamento e Educação
 

--- a/release-pt-br/10-culture-process/00-toc.md
+++ b/release-pt-br/10-culture-process/00-toc.md
@@ -11,7 +11,7 @@ order:
 
 {% include breadcrumb.html %}
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){height=180px}
+![WIP logo](../../assets/images/dg_wip.png "Trabalho em andamento"){height=180px}
 
 ## 8. Construção de cultura e Amadurecimento de processos
 

--- a/release-pt-br/10-culture-process/02-security-champions/01-security-champions-program.md
+++ b/release-pt-br/10-culture-process/02-security-champions/01-security-champions-program.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/construção_cultura_amadurecimento_processos/campeõe
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 8.2.1 Programa de Campeões de Segurança
 

--- a/release-pt-br/10-culture-process/02-security-champions/02-security-champions-guide.md
+++ b/release-pt-br/10-culture-process/02-security-champions/02-security-champions-guide.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/construção_cultura_amadurecimento_processos/campeõe
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 8.2.2 Security Champions Guide
 

--- a/release-pt-br/10-culture-process/02-security-champions/03-security-champions-playbook.md
+++ b/release-pt-br/10-culture-process/02-security-champions/03-security-champions-playbook.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/construção_cultura_amadurecimento_processos/campeõe
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 8.2.3 Security Champions Playbook
 

--- a/release-pt-br/10-culture-process/toc.md
+++ b/release-pt-br/10-culture-process/toc.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/construção_cultura_amadurecimento_processos/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ## 8. Construção de cultura e Amadurecimento de processos
 

--- a/release-pt-br/11-operations/00-toc.md
+++ b/release-pt-br/11-operations/00-toc.md
@@ -11,7 +11,7 @@ order:
 
 {% include breadcrumb.html %}
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){height=180px}
+![WIP logo](../../assets/images/dg_wip.png "Trabalho em andamento"){height=180px}
 
 ## 9. Operações
 

--- a/release-pt-br/11-operations/toc.md
+++ b/release-pt-br/11-operations/toc.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/operações/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ## 9. Operações
 

--- a/release-pt-br/12-metrics/00-toc.md
+++ b/release-pt-br/12-metrics/00-toc.md
@@ -11,7 +11,7 @@ order:
 
 {% include breadcrumb.html %}
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){height=180px}
+![WIP logo](../../assets/images/dg_wip.png "Trabalho em andamento"){height=180px}
 
 ## 10. Métricas
 

--- a/release-pt-br/12-metrics/toc.md
+++ b/release-pt-br/12-metrics/toc.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/métricas/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ## 10. Métricas
 

--- a/release-pt-br/13-security-gap-analysis/00-toc.md
+++ b/release-pt-br/13-security-gap-analysis/00-toc.md
@@ -11,7 +11,7 @@ order:
 
 {% include breadcrumb.html %}
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){height=180px}
+![WIP logo](../../assets/images/dg_wip.png "Trabalho em andamento"){height=180px}
 
 ## 11. Análise de lacunas de segurança
 

--- a/release-pt-br/13-security-gap-analysis/01-guides/01-samm.md
+++ b/release-pt-br/13-security-gap-analysis/01-guides/01-samm.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/análise_lacunas_segurança/guias/samm/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 11.1.1 SAMM análise
 

--- a/release-pt-br/13-security-gap-analysis/01-guides/02-asvs.md
+++ b/release-pt-br/13-security-gap-analysis/01-guides/02-asvs.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/análise_lacunas_segurança/guias/asvs/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 11.1.2 ASVS análise
 

--- a/release-pt-br/13-security-gap-analysis/01-guides/03-mas.md
+++ b/release-pt-br/13-security-gap-analysis/01-guides/03-mas.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/análise_lacunas_segurança/guias/mas/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 11.1.3 MAS análise
 

--- a/release-pt-br/13-security-gap-analysis/toc.md
+++ b/release-pt-br/13-security-gap-analysis/toc.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/análise_lacunas_segurança/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ## 11. Análise de lacunas de segurança
 

--- a/release-pt-br/14-appendices/01-implementation-dos-donts/01-container-security.md
+++ b/release-pt-br/14-appendices/01-implementation-dos-donts/01-container-security.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/appendices/implementação/segurança_containers/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 12.1.1 Segurança de containers
 

--- a/release-pt-br/14-appendices/01-implementation-dos-donts/02-secure-coding.md
+++ b/release-pt-br/14-appendices/01-implementation-dos-donts/02-secure-coding.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/appendices/implementação/codificação_segura/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 12.1.2 Codificação segura
 

--- a/release-pt-br/14-appendices/01-implementation-dos-donts/03-cryptographic-practices.md
+++ b/release-pt-br/14-appendices/01-implementation-dos-donts/03-cryptographic-practices.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/appendices/implementação/práticas_criptografia/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 12.1.3 Práticas de criptografia
 

--- a/release-pt-br/14-appendices/01-implementation-dos-donts/04-application-spoofing.md
+++ b/release-pt-br/14-appendices/01-implementation-dos-donts/04-application-spoofing.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/appendices/implementação/spoofing_applicação/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 12.1.4 Spoofing de Aplicação
 

--- a/release-pt-br/14-appendices/01-implementation-dos-donts/05-content-security-policy.md
+++ b/release-pt-br/14-appendices/01-implementation-dos-donts/05-content-security-policy.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/appendices/implementação/csp/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 12.1.5 Política de Segurança de Conteúdo (CSP)
 

--- a/release-pt-br/14-appendices/01-implementation-dos-donts/06-exception-error-handling.md
+++ b/release-pt-br/14-appendices/01-implementation-dos-donts/06-exception-error-handling.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/appendices/implementação/tratamento_erros_exceções
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 12.1.6 Tratamento de erros e exceções
 

--- a/release-pt-br/14-appendices/01-implementation-dos-donts/07-file-management.md
+++ b/release-pt-br/14-appendices/01-implementation-dos-donts/07-file-management.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/appendices/implementação/gerenciamento_arquivos/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 12.1.7 Gerenciamento de arquivos
 

--- a/release-pt-br/14-appendices/01-implementation-dos-donts/08-memory-management.md
+++ b/release-pt-br/14-appendices/01-implementation-dos-donts/08-memory-management.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/appendices/implementação/gerenciamento_memória/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 12.1.8 Gerenciamento de memória
 

--- a/release-pt-br/14-appendices/02-verification-dos-donts/01-secure-environment.md
+++ b/release-pt-br/14-appendices/02-verification-dos-donts/01-secure-environment.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/appendices/verificação/ambiente_seguro/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 12.2.1 Ambiente seguro
 

--- a/release-pt-br/14-appendices/02-verification-dos-donts/02-system-hardening.md
+++ b/release-pt-br/14-appendices/02-verification-dos-donts/02-system-hardening.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/appendices/verificação/hardening_sistemas/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 12.2.2 Hardening de sistemas
 

--- a/release-pt-br/14-appendices/02-verification-dos-donts/03-open-source-software.md
+++ b/release-pt-br/14-appendices/02-verification-dos-donts/03-open-source-software.md
@@ -22,7 +22,7 @@ permalink: /release-pt-br/appendices/verificação/software_código_aberto/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabalho em andamento"){: .image-right }
 
 ### 12.2.3 Software de Código Aberto
 


### PR DESCRIPTION
**Summary** :
The Work In Progress logo (`dg_wip.png`) is _not being found_ in some of the pt-br pages . Example:

<img width="690" alt="image" src="https://github.com/user-attachments/assets/28602bea-692a-482e-9d45-177deee085d4" />


This is happening simply due to the presence of incorrect relative paths to `dg_wip.png`.

**Description for the changelog** :  
Multiple files under [/release-pt-br](https://github.com/OWASP/www-project-developer-guide/tree/main/release-pt-br).