### PR TITLE
Fix WIP logo not found error in release-es pages

### DIFF
--- a/release-es/05-requirements/00-toc.md
+++ b/release-es/05-requirements/00-toc.md
@@ -12,7 +12,7 @@ permalink:
 
 {% include breadcrumb.html %}
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){height=180px}
+![WIP logo](../../assets/images/dg_wip.png "Trabajo en curso"){height=180px}
 
 ## 3. Requerimientos
 

--- a/release-es/05-requirements/toc.md
+++ b/release-es/05-requirements/toc.md
@@ -22,7 +22,7 @@ permalink: /release-es/requerimientos/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ## 3. Requerimientos
 

--- a/release-es/06-design/00-toc.md
+++ b/release-es/06-design/00-toc.md
@@ -11,7 +11,7 @@ order:
 
 {% include breadcrumb.html %}
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){height=180px}
+![WIP logo](../../assets/images/dg_wip.png "Trabajo en curso"){height=180px}
 
 ## 4. Diseño
 

--- a/release-es/06-design/01-threat-modeling/01-threat-modeling.md
+++ b/release-es/06-design/01-threat-modeling/01-threat-modeling.md
@@ -22,7 +22,7 @@ permalink: /release-es/diseño/modelado_amenazas/modelado_amenazas_práctica/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 4.1.1 Modelado de amenazas en la práctica
 

--- a/release-es/06-design/01-threat-modeling/02-pytm.md
+++ b/release-es/06-design/01-threat-modeling/02-pytm.md
@@ -22,7 +22,7 @@ permalink: /release-es/diseño/modelado_amenazas/pytm/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 4.1.2 pytm
 

--- a/release-es/06-design/01-threat-modeling/03-threat-dragon.md
+++ b/release-es/06-design/01-threat-modeling/03-threat-dragon.md
@@ -22,7 +22,7 @@ permalink: /release-es/diseño/modelado_amenazas/threat_dragon/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 4.1.3 Threat Dragon
 

--- a/release-es/06-design/01-threat-modeling/04-cornucopia.md
+++ b/release-es/06-design/01-threat-modeling/04-cornucopia.md
@@ -22,7 +22,7 @@ permalink: /release-es/diseño/modelado_amenazas/cornucopia/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 4.1.4 Cornucopia
 

--- a/release-es/06-design/01-threat-modeling/05-linddun-go.md
+++ b/release-es/06-design/01-threat-modeling/05-linddun-go.md
@@ -22,7 +22,7 @@ permalink: /release-es/diseño/modelado_amenazas/linddun-go/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 4.1.5 LINDDUN GO
 

--- a/release-es/06-design/01-threat-modeling/06-toolkit.md
+++ b/release-es/06-design/01-threat-modeling/06-toolkit.md
@@ -22,7 +22,7 @@ permalink: /release-es/diseño/modelado_amenazas/toolkit/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 4.1.6 Kit de herramientas de modelado de amenazas
 

--- a/release-es/06-design/02-web-app-checklist/01-define-security-requirements.md
+++ b/release-es/06-design/02-web-app-checklist/01-define-security-requirements.md
@@ -22,7 +22,7 @@ permalink: /release-es/diseño/lista_verificación_web/definir_requisitos_seguri
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 4.2.1 Definir requisitos de seguridad
 

--- a/release-es/06-design/02-web-app-checklist/02-frameworks-libraries.md
+++ b/release-es/06-design/02-web-app-checklist/02-frameworks-libraries.md
@@ -22,7 +22,7 @@ permalink: /release-es/diseño/lista_verificación_web/aprovechar_frameworks_lib
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 4.2.2 Aprovechar los frameworks y librerías
 

--- a/release-es/06-design/02-web-app-checklist/03-secure-database-access.md
+++ b/release-es/06-design/02-web-app-checklist/03-secure-database-access.md
@@ -22,7 +22,7 @@ permalink: /release-es/diseño/lista_verificación_web/asegurar_base_datos/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 4.2.3 Asegurar el acceso a la base de datos
 

--- a/release-es/06-design/02-web-app-checklist/04-encode-escape-data.md
+++ b/release-es/06-design/02-web-app-checklist/04-encode-escape-data.md
@@ -22,7 +22,7 @@ permalink: /release-es/diseño/lista_verificación_web/codificar_escapar_datos/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 4.2.4 Codificar y escapar caracteres especiales en datos
 

--- a/release-es/06-design/02-web-app-checklist/05-validate-inputs.md
+++ b/release-es/06-design/02-web-app-checklist/05-validate-inputs.md
@@ -22,7 +22,7 @@ permalink: /release-es/diseño/lista_verificación_web/validar_entradas/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 4.2.5 Validar todas las entradas
 

--- a/release-es/06-design/02-web-app-checklist/06-digital-identity.md
+++ b/release-es/06-design/02-web-app-checklist/06-digital-identity.md
@@ -22,7 +22,7 @@ permalink: /release-es/diseño/lista_verificación_web/identidad_digital/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 4.2.6 Implementar identidad digital
 

--- a/release-es/06-design/02-web-app-checklist/07-access-controls.md
+++ b/release-es/06-design/02-web-app-checklist/07-access-controls.md
@@ -22,7 +22,7 @@ permalink: /release-es/diseño/lista_verificación_web/controles_acceso/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 4.2.7 Hacer respetar los controles de acceso
 

--- a/release-es/06-design/02-web-app-checklist/08-protect-data.md
+++ b/release-es/06-design/02-web-app-checklist/08-protect-data.md
@@ -22,7 +22,7 @@ permalink: /release-es/diseño/lista_verificación_web/proteger_datos/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 4.2.8 Proteger los datos en todas partes
 

--- a/release-es/06-design/02-web-app-checklist/09-logging-monitoring.md
+++ b/release-es/06-design/02-web-app-checklist/09-logging-monitoring.md
@@ -22,7 +22,7 @@ permalink: /release-es/diseño/lista_verificación_web/registro_monitoreo/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 4.2.9 Implementar registro y monitoreo
 

--- a/release-es/06-design/02-web-app-checklist/10-handle-errors-exceptions.md
+++ b/release-es/06-design/02-web-app-checklist/10-handle-errors-exceptions.md
@@ -22,7 +22,7 @@ permalink: /release-es/diseño/lista_verificación_web/errores_excepciones/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 4.2.10 Manejar todos los errores y excepciones
 

--- a/release-es/06-design/toc.md
+++ b/release-es/06-design/toc.md
@@ -22,7 +22,7 @@ permalink: /release-es/diseño/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ## 4. Diseño
 

--- a/release-es/07-implementation/00-toc.md
+++ b/release-es/07-implementation/00-toc.md
@@ -11,7 +11,7 @@ order:
 
 {% include breadcrumb.html %}
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){height=180px}
+![WIP logo](../../assets/images/dg_wip.png "Trabajo en curso"){height=180px}
 
 ## 5. Implementación
 

--- a/release-es/07-implementation/01-documentation/01-proactive-controls.md
+++ b/release-es/07-implementation/01-documentation/01-proactive-controls.md
@@ -22,7 +22,7 @@ permalink: /release-es/implementación/documentación/controles_proactivos/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 5.1.1 Los Top 10 controles proactivos
 

--- a/release-es/07-implementation/01-documentation/02-go-scp.md
+++ b/release-es/07-implementation/01-documentation/02-go-scp.md
@@ -22,7 +22,7 @@ permalink: /release-es/implementación/documentación/goscp/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 5.1.2 GoSCP (Prácticas de codificación seguras de Go)
 

--- a/release-es/07-implementation/01-documentation/03-cheatsheets.md
+++ b/release-es/07-implementation/01-documentation/03-cheatsheets.md
@@ -22,7 +22,7 @@ permalink: /release-es/implementación/documentación/serie_referencia/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 5.1.3 Serie de hojas de referencia
 

--- a/release-es/07-implementation/02-dependencies/01-dependency-check.md
+++ b/release-es/07-implementation/02-dependencies/01-dependency-check.md
@@ -22,7 +22,7 @@ permalink: /release-es/implementación/dependencias/dependency_check/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 5.2.1 Dependency-Check
 

--- a/release-es/07-implementation/02-dependencies/02-dependency-track.md
+++ b/release-es/07-implementation/02-dependencies/02-dependency-track.md
@@ -22,7 +22,7 @@ permalink: /release-es/implementación/dependencias/dependency_track/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 5.2.2 Dependency-Track
 

--- a/release-es/07-implementation/02-dependencies/03-cyclonedx.md
+++ b/release-es/07-implementation/02-dependencies/03-cyclonedx.md
@@ -22,7 +22,7 @@ permalink: /release-es/implementación/dependencias/cyclonedx/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 5.2.3 CycloneDX
 

--- a/release-es/07-implementation/03-secure-libraries/01-esapi.md
+++ b/release-es/07-implementation/03-secure-libraries/01-esapi.md
@@ -22,7 +22,7 @@ permalink: /release-es/implementación/librerías_seguras/esapi/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 5.3.1 ESAPI
 

--- a/release-es/07-implementation/03-secure-libraries/02-csrf-guard.md
+++ b/release-es/07-implementation/03-secure-libraries/02-csrf-guard.md
@@ -22,7 +22,7 @@ permalink: /release-es/implementación/librerías_seguras/csrfguard/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 5.3.2 CSRFGuard
 

--- a/release-es/07-implementation/03-secure-libraries/03-secure-headers.md
+++ b/release-es/07-implementation/03-secure-libraries/03-secure-headers.md
@@ -22,7 +22,7 @@ permalink: /release-es/implementación/librerías_seguras/oshp/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 5.3.3 OSHP
 

--- a/release-es/07-implementation/toc.md
+++ b/release-es/07-implementation/toc.md
@@ -22,7 +22,7 @@ permalink: /release-es/implementación/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ## 5. Implementación
 

--- a/release-es/08-verification/00-toc.md
+++ b/release-es/08-verification/00-toc.md
@@ -11,7 +11,7 @@ order:
 
 {% include breadcrumb.html %}
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){height=180px}
+![WIP logo](../../assets/images/dg_wip.png "Trabajo en curso"){height=180px}
 
 ## 6. Verificación
 

--- a/release-es/08-verification/01-guides/01-wstg.md
+++ b/release-es/08-verification/01-guides/01-wstg.md
@@ -22,7 +22,7 @@ permalink: /release-es/verificación/guías/wstg/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 6.1.1 WSTG
 

--- a/release-es/08-verification/01-guides/02-mastg.md
+++ b/release-es/08-verification/01-guides/02-mastg.md
@@ -22,7 +22,7 @@ permalink: /release-es/verificación/guías/mastg/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 6.1.2 MASTG
 

--- a/release-es/08-verification/01-guides/03-asvs.md
+++ b/release-es/08-verification/01-guides/03-asvs.md
@@ -22,7 +22,7 @@ permalink: /release-es/verificación/guías/asvs/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 6.1.3 ASVS
 

--- a/release-es/08-verification/02-tools/01-dast.md
+++ b/release-es/08-verification/02-tools/01-dast.md
@@ -22,7 +22,7 @@ permalink: /release-es/verificación/herramientas/dast/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 6.2.1 DAST
 

--- a/release-es/08-verification/02-tools/02-amass.md
+++ b/release-es/08-verification/02-tools/02-amass.md
@@ -22,7 +22,7 @@ permalink: /release-es/verificación/herramientas/amass/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 6.2.2 Amass
 

--- a/release-es/08-verification/02-tools/03-owtf.md
+++ b/release-es/08-verification/02-tools/03-owtf.md
@@ -22,7 +22,7 @@ permalink: /release-es/verificación/herramientas/owtf/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 6.2.3 OWTF
 

--- a/release-es/08-verification/02-tools/04-nettacker.md
+++ b/release-es/08-verification/02-tools/04-nettacker.md
@@ -22,7 +22,7 @@ permalink: /release-es/verificación/herramientas/nettacker/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 6.2.4 Nettacker
 

--- a/release-es/08-verification/02-tools/05-secure-headers.md
+++ b/release-es/08-verification/02-tools/05-secure-headers.md
@@ -22,7 +22,7 @@ permalink: /release-es/verificación/herramientas/oshp/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 6.2.5 OSHP verificación
 

--- a/release-es/08-verification/03-frameworks/01-secure-codebox.md
+++ b/release-es/08-verification/03-frameworks/01-secure-codebox.md
@@ -22,7 +22,7 @@ permalink: /release-es/verificación/frameworks/secure_codebox/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 #### 6.3.1 secureCodeBox
 

--- a/release-es/08-verification/04-vulnerability-management/01-defectdojo.md
+++ b/release-es/08-verification/04-vulnerability-management/01-defectdojo.md
@@ -22,7 +22,7 @@ permalink: /release-es/verificación/gestión_vulnerabilidades/defectdojo/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 6.4.1 DefectDojo
 

--- a/release-es/08-verification/toc.md
+++ b/release-es/08-verification/toc.md
@@ -22,7 +22,7 @@ permalink: /release-es/verificación/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ## 6. Verificación
 

--- a/release-es/09-training-education/00-toc.md
+++ b/release-es/09-training-education/00-toc.md
@@ -11,7 +11,7 @@ order:
 
 {% include breadcrumb.html %}
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){height=180px}
+![WIP logo](../../assets/images/dg_wip.png "Trabajo en curso"){height=180px}
 
 ## 7. Capacitación y Educación
 

--- a/release-es/09-training-education/01-vulnerable-apps/01-juice-shop.md
+++ b/release-es/09-training-education/01-vulnerable-apps/01-juice-shop.md
@@ -22,7 +22,7 @@ permalink: /release-es/capacitación_educación/aplicaciones_vulnerables/juice_s
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 7.1.1 Juice Shop
 

--- a/release-es/09-training-education/01-vulnerable-apps/02-webgoat.md
+++ b/release-es/09-training-education/01-vulnerable-apps/02-webgoat.md
@@ -22,7 +22,7 @@ permalink: /release-es/capacitación_educación/aplicaciones_vulnerables/webgoat
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 7.1.2 WebGoat
 

--- a/release-es/09-training-education/01-vulnerable-apps/03-pygoat.md
+++ b/release-es/09-training-education/01-vulnerable-apps/03-pygoat.md
@@ -22,7 +22,7 @@ permalink: /release-es/capacitación_educación/aplicaciones_vulnerables/pygoat/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 7.1.3 PyGoat
 

--- a/release-es/09-training-education/01-vulnerable-apps/04-security-shepherd.md
+++ b/release-es/09-training-education/01-vulnerable-apps/04-security-shepherd.md
@@ -22,7 +22,7 @@ permalink: /release-es/capacitación_educación/aplicaciones_vulnerables/securit
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 7.1.4 Security Shepherd
 

--- a/release-es/09-training-education/toc.md
+++ b/release-es/09-training-education/toc.md
@@ -22,7 +22,7 @@ permalink: /release-es/capacitación_educación/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ## 7. Capacitación y Educación
 

--- a/release-es/10-culture-process/00-toc.md
+++ b/release-es/10-culture-process/00-toc.md
@@ -11,7 +11,7 @@ order:
 
 {% include breadcrumb.html %}
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){height=180px}
+![WIP logo](../../assets/images/dg_wip.png "Trabajo en curso"){height=180px}
 
 ## 8. Desarrollo de cultura y maduración de procesos
 

--- a/release-es/10-culture-process/02-security-champions/01-security-champions-program.md
+++ b/release-es/10-culture-process/02-security-champions/01-security-champions-program.md
@@ -22,7 +22,7 @@ permalink: /release-es/desarrollo_cultura_maduración_procesos/defensores_seguri
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 8.2.1 Programa de Defensores de seguridad
 

--- a/release-es/10-culture-process/02-security-champions/02-security-champions-guide.md
+++ b/release-es/10-culture-process/02-security-champions/02-security-champions-guide.md
@@ -22,7 +22,7 @@ permalink: /release-es/desarrollo_cultura_maduración_procesos/defensores_seguri
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 8.2.2 Security Champions Guide
 

--- a/release-es/10-culture-process/02-security-champions/03-security-champions-playbook.md
+++ b/release-es/10-culture-process/02-security-champions/03-security-champions-playbook.md
@@ -22,7 +22,7 @@ permalink: /release-es/desarrollo_cultura_maduración_procesos/defensores_seguri
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 8.2.3 Security Champions Playbook
 

--- a/release-es/10-culture-process/toc.md
+++ b/release-es/10-culture-process/toc.md
@@ -22,7 +22,7 @@ permalink: /release-es/desarrollo_cultura_maduración_procesos/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ## 8. Desarrollo de cultura y maduración de procesos
 

--- a/release-es/11-operations/00-toc.md
+++ b/release-es/11-operations/00-toc.md
@@ -11,7 +11,7 @@ order:
 
 {% include breadcrumb.html %}
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){height=180px}
+![WIP logo](../../assets/images/dg_wip.png "Trabajo en curso"){height=180px}
 
 ## 9. Operaciones
 

--- a/release-es/11-operations/toc.md
+++ b/release-es/11-operations/toc.md
@@ -22,7 +22,7 @@ permalink: /release-es/operaciones/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ## 9. Operaciones
 

--- a/release-es/12-metrics/00-toc.md
+++ b/release-es/12-metrics/00-toc.md
@@ -11,7 +11,7 @@ order:
 
 {% include breadcrumb.html %}
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){height=180px}
+![WIP logo](../../assets/images/dg_wip.png "Trabajo en curso"){height=180px}
 
 ## 10. Métricas
 

--- a/release-es/12-metrics/toc.md
+++ b/release-es/12-metrics/toc.md
@@ -22,7 +22,7 @@ permalink: /release-es/métricas/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ## 10. Métricas
 

--- a/release-es/13-security-gap-analysis/00-toc.md
+++ b/release-es/13-security-gap-analysis/00-toc.md
@@ -11,7 +11,7 @@ order:
 
 {% include breadcrumb.html %}
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){height=180px}
+![WIP logo](../../assets/images/dg_wip.png "Trabajo en curso"){height=180px}
 
 ## 11. Análisis de brechas de seguridad
 

--- a/release-es/13-security-gap-analysis/01-guides/01-samm.md
+++ b/release-es/13-security-gap-analysis/01-guides/01-samm.md
@@ -22,7 +22,7 @@ permalink: /release-es/análisis_brechas_seguridad/guías/samm/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 11.1.1 SAMM análisis
 

--- a/release-es/13-security-gap-analysis/01-guides/02-asvs.md
+++ b/release-es/13-security-gap-analysis/01-guides/02-asvs.md
@@ -22,7 +22,7 @@ permalink: /release-es/análisis_brechas_seguridad/guías/asvs/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 11.1.2 ASVS análisis
 

--- a/release-es/13-security-gap-analysis/01-guides/03-mas.md
+++ b/release-es/13-security-gap-analysis/01-guides/03-mas.md
@@ -22,7 +22,7 @@ permalink: /release-es/análisis_brechas_seguridad/guías/mas/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 11.1.3 MAS análisis
 

--- a/release-es/13-security-gap-analysis/toc.md
+++ b/release-es/13-security-gap-analysis/toc.md
@@ -22,7 +22,7 @@ permalink: /release-es/análisis_brechas_seguridad/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ## 11. Análisis de brechas de seguridad
 

--- a/release-es/14-appendices/01-implementation-dos-donts/01-container-security.md
+++ b/release-es/14-appendices/01-implementation-dos-donts/01-container-security.md
@@ -22,7 +22,7 @@ permalink: /release-es/apéndices/qué_hacer_implementación/seguridad_contenedo
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 12.1.1 Seguridad de Contenedores
 

--- a/release-es/14-appendices/01-implementation-dos-donts/02-secure-coding.md
+++ b/release-es/14-appendices/01-implementation-dos-donts/02-secure-coding.md
@@ -22,7 +22,7 @@ permalink: /release-es/apéndices/qué_hacer_implementación/codificación_segur
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 12.1.2 Codificación segura
 

--- a/release-es/14-appendices/01-implementation-dos-donts/03-cryptographic-practices.md
+++ b/release-es/14-appendices/01-implementation-dos-donts/03-cryptographic-practices.md
@@ -22,7 +22,7 @@ permalink: /release-es/apéndices/qué_hacer_implementación/prácticas_criptogr
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 12.1.3 Prácticas criptográficas
 

--- a/release-es/14-appendices/01-implementation-dos-donts/04-application-spoofing.md
+++ b/release-es/14-appendices/01-implementation-dos-donts/04-application-spoofing.md
@@ -22,7 +22,7 @@ permalink: /release-es/apéndices/qué_hacer_implementación/suplantación_aplic
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 12.1.4 Suplantación de aplicaciones
 

--- a/release-es/14-appendices/01-implementation-dos-donts/05-content-security-policy.md
+++ b/release-es/14-appendices/01-implementation-dos-donts/05-content-security-policy.md
@@ -22,7 +22,7 @@ permalink: /release-es/apéndices/qué_hacer_implementación/csp/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 12.1.5 Política de seguridad de contenido (CSP)
 

--- a/release-es/14-appendices/01-implementation-dos-donts/06-exception-error-handling.md
+++ b/release-es/14-appendices/01-implementation-dos-donts/06-exception-error-handling.md
@@ -22,7 +22,7 @@ permalink: /release-es/apéndices/qué_hacer_implementación/excepciones_errores
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 12.1.6 Manejo de excepciones y errores
 

--- a/release-es/14-appendices/01-implementation-dos-donts/07-file-management.md
+++ b/release-es/14-appendices/01-implementation-dos-donts/07-file-management.md
@@ -22,7 +22,7 @@ permalink: /release-es/apéndices/qué_hacer_implementación/administración_arc
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 12.1.7 Administración de archivos
 

--- a/release-es/14-appendices/01-implementation-dos-donts/08-memory-management.md
+++ b/release-es/14-appendices/01-implementation-dos-donts/08-memory-management.md
@@ -22,7 +22,7 @@ permalink: /release-es/apéndices/qué_hacer_implementación/administración_mem
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 12.1.8 Administración de memoria
 

--- a/release-es/14-appendices/02-verification-dos-donts/01-secure-environment.md
+++ b/release-es/14-appendices/02-verification-dos-donts/01-secure-environment.md
@@ -22,7 +22,7 @@ permalink: /release-es/apéndices/qué_hacer_verificación/entorno_seguro/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 12.2.1 Entorno seguro
 

--- a/release-es/14-appendices/02-verification-dos-donts/02-system-hardening.md
+++ b/release-es/14-appendices/02-verification-dos-donts/02-system-hardening.md
@@ -22,7 +22,7 @@ permalink: /release-es/apéndices/qué_hacer_verificación/refuerzo_sistema/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 12.2.2 Refuerzo de seguridad del sistema
 

--- a/release-es/14-appendices/02-verification-dos-donts/03-open-source-software.md
+++ b/release-es/14-appendices/02-verification-dos-donts/03-open-source-software.md
@@ -22,7 +22,7 @@ permalink: /release-es/apéndices/qué_hacer_verificación/software_abierto/
 }
 </style>
 
-![WIP logo](../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
+![WIP logo](../../../../assets/images/dg_wip.png "Trabajo en curso"){: .image-right }
 
 ### 12.2.3 Software de código abierto
 


### PR DESCRIPTION
**Summary** : 
Similar to https://github.com/OWASP/www-project-developer-guide/pull/340. 
The Work In Progress logo (dg_wip.png) is _not being found_ in some of the _release-es_ pages . Example:

<img width="600" alt="image" src="https://github.com/user-attachments/assets/fc221cb2-1dac-41d9-8bec-91acc38d55b5" />

This is happening simply due to incorrect relative paths to dg_wip.png.

**Description for the changelog** :  
Multiple files under [/release-es](https://github.com/OWASP/www-project-developer-guide/tree/main/release-es).