### PR TITLE
updated crypto principles to match today's cryptographic standards, and fixed grammatical issues

### DIFF
--- a/draft/04-foundations/04-crypto-principles.md
+++ b/draft/04-foundations/04-crypto-principles.md
@@ -5,8 +5,8 @@ layout: col-document
 tags: OWASP Developer Guide
 contributors: Jon Gadsden
 document: OWASP Developer Guide
-order: 404
-permalink: /draft/foundations/crypto_principles/
+order: 4040
+permalink: /release/foundations/crypto_principles/
 
 ---
 
@@ -30,7 +30,7 @@ of cryptography by the development team for the application or system.
 
 Although cryptography was initially restricted primarily to the military and the realm of academia,
 cryptography has become ubiquitous in securing software applications.
-Common every day uses of cryptography include mobile phones, passwords, SSL VPNs, smart cards, and DVDs.
+Common every day uses of cryptography include cloud storage, passwords, SSL VPNs, smart cards, and end-to-end encrypted messaging apps.
 Cryptography has permeated through everyday life, and is heavily used by many web applications.
 
 Cryptography is one of the more advanced topics of information security,
@@ -40,7 +40,7 @@ each with advantages and disadvantages that need to be thoroughly understood by 
 
 The proper and accurate implementation of cryptography is extremely critical to its efficacy.
 A small mistake in configuration or coding will result in removing most of the protection
-and rending the crypto implementation useless.
+and rendering the crypto implementation useless.
 
 A good understanding of crypto is required to be able to discern between solid products and snake oil.
 The inherent complexity of crypto makes it easy to fall for fantastic claims from vendors about their product.
@@ -50,9 +50,8 @@ If a vendor says "trust us, we have had experts look at this," chances are they 
 #### Confidentiality
 
 For the purposes of this section, confidentiality is defined as "no unauthorized disclosure of information".
-Cryptography addresses this via encryption of either the data at rest or data in transit by
+Cryptography addresses this via encryption of either the [data at rest][cstorage] or data in transit by
 protecting the information from all who do not hold the decryption key.
-Cryptographic hashes (secure, one way hashes) to prevent passwords from disclosure.
 
 #### Authentication
 
@@ -63,15 +62,15 @@ Cryptography is central to authentication:
 1. to protect the provided corroborating evidence (for example hashing of passwords for subsequent storage)
 2. in authentication protocols often use cryptography to either directly authenticate entities
     or to exchange credentials in a secure manner
-3. to verify the identity one or both parties in exchanging messages,
-    for example identity verification within [Transport Layer Security][tls] (TLS)
+3. to verify the identity of one or both parties in exchanging messages,
+    for example identity verification within [Transport Layer Security v1.3][tls] (TLS)
 
 OpenID Connect is widely used as an identity layer on top of the OAuth 2.0 protocol,
 see the [OAuth 2.0 Protocol][csoauth] Cheat Sheet.
 
 #### Integrity
 
-Integrity ensures that even authorized users have performed no accidental or malicious alternation of information.
+Integrity ensures that even authorized users have performed no accidental or malicious alteration of information.
 Cryptography can be used to prevent tampering by means of Message Authentication Codes (MACs) or digital signatures.
 
 The term 'message authenticity' refers to ensuring the integrity of information,
@@ -83,8 +82,9 @@ and, if asymmetric encryption is used, can authenticate the sender.
 
 #### Non-repudiation
 
-Non-repudiation of sender ensures that someone sending a message should not be able to deny later that they have sent it.
+Non-repudiation ensures that a sender cannot later deny having sent a message.
 Non-repudiation of receiver means that the receiver of a message should not be able to deny that they have received it.
+
 Cryptography can be used to provide non-repudiation by providing unforgeable messages or replies to messages.
 
 Non-repudiation is useful for financial, e-commerce, and contractual exchanges.
@@ -142,20 +142,22 @@ Symmetric ciphers come in two main types:
 1. Block ciphers, which operate on a block of characters (typically 8 or 16 octets) at a time.
     An example of a block cipher is AES
 2. Stream ciphers, which operate on a single bit (or occasionally a single byte) at a time.
-    Examples of a stream ciphers are RC4 (aka, ARC4) and Salsa20
+    Examples of stream ciphers are ChaCha20 (often paired with Poly1305) and Salsa20
 
 Note that all block ciphers can also operate in 'streaming mode' by selecting the appropriate cipher mode.
 
 #### Cipher Modes
 
-Block ciphers can function in different modes of operations known as "cipher modes".
+Block ciphers can function in different modes of operation known as "cipher modes".
 This cipher mode algorithmically describes how a cipher operates to repeatedly
 apply its encryption or decryption mechanism to a given cipher block.
 Cipher modes are important because they have an enormous impact on both the confidentiality
 and the message authenticity of the resulting ciphertext messages.
 
-Almost all cryptographic libraries support the four original DES cipher modes of ECB, CBC (Cipher Block Chaining)
+Almost all cryptographic libraries support the four original DES cipher modes of ECB (Electronic Code Book), CBC (Cipher Block Chaining)
 OFB (Output Feedback), and CFB (Cipher Feedback). Many also support CTR (Counter) mode.
+
+Note that the DES modes are insecure and aren't used today. Modern standards indicate the use of AEAD (Authenticated Encryption with Associated Data) modes that work on both block ciphers and stream ciphers, such as GCM (Galois Counter Mode), CCM (Counter with CBC-MAC), OCB (Offset Codebook Mode) and EAX (Encrypt-Then-Authenticate-and-Translate).
 
 #### Initialization vector
 
@@ -182,7 +184,7 @@ which is only used for the duration of the encrypted communication.
 This random session key is then encrypted using an asymmetric cipher and the recipient's private key.
 The plaintext data itself is encrypted with the session key.
 Then the entire bundle (encrypted session key and encrypted message) is all sent together.
-Both [TLS][tls] and S/MIME are common cryptosystems using hybrid cryptography.
+Both [TLS 1.3][tls] and S/MIME are common cryptosystems using hybrid cryptography today.
 
 #### Digital signature
 
@@ -248,6 +250,7 @@ These protocols prevent adversaries from learning the key or forcing their own k
   * [SAML Security][sscs]
   * [Secure Product Design][spdcs]
   * [User Privacy Protection][uppcs]
+  * [Cryptographic storage][cstorage]
 
 ----
 
@@ -266,5 +269,4 @@ then [submit an issue][issue0404] or [edit on GitHub][edit0404].
 [spdcs]: https://cheatsheetseries.owasp.org/cheatsheets/Secure_Product_Design_Cheat_Sheet
 [tls]: https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Security_Cheat_Sheet
 [uppcs]: https://cheatsheetseries.owasp.org/cheatsheets/User_Privacy_Protection_Cheat_Sheet
-
-\newpage
+[cstorage]: https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html

--- a/release/04-foundations/04-crypto-principles.md
+++ b/release/04-foundations/04-crypto-principles.md
@@ -30,7 +30,7 @@ of cryptography by the development team for the application or system.
 
 Although cryptography was initially restricted primarily to the military and the realm of academia,
 cryptography has become ubiquitous in securing software applications.
-Common every day uses of cryptography include mobile phones, passwords, SSL VPNs, smart cards, and DVDs.
+Common every day uses of cryptography include cloud storage, passwords, SSL VPNs, smart cards, and end-to-end encrypted messaging apps.
 Cryptography has permeated through everyday life, and is heavily used by many web applications.
 
 Cryptography is one of the more advanced topics of information security,
@@ -40,7 +40,7 @@ each with advantages and disadvantages that need to be thoroughly understood by 
 
 The proper and accurate implementation of cryptography is extremely critical to its efficacy.
 A small mistake in configuration or coding will result in removing most of the protection
-and rending the crypto implementation useless.
+and rendering the crypto implementation useless.
 
 A good understanding of crypto is required to be able to discern between solid products and snake oil.
 The inherent complexity of crypto makes it easy to fall for fantastic claims from vendors about their product.
@@ -50,9 +50,8 @@ If a vendor says "trust us, we have had experts look at this," chances are they 
 #### Confidentiality
 
 For the purposes of this section, confidentiality is defined as "no unauthorized disclosure of information".
-Cryptography addresses this via encryption of either the data at rest or data in transit by
+Cryptography addresses this via encryption of either the [data at rest][cstorage] or data in transit by
 protecting the information from all who do not hold the decryption key.
-Cryptographic hashes (secure, one way hashes) to prevent passwords from disclosure.
 
 #### Authentication
 
@@ -63,15 +62,15 @@ Cryptography is central to authentication:
 1. to protect the provided corroborating evidence (for example hashing of passwords for subsequent storage)
 2. in authentication protocols often use cryptography to either directly authenticate entities
     or to exchange credentials in a secure manner
-3. to verify the identity one or both parties in exchanging messages,
-    for example identity verification within [Transport Layer Security][tls] (TLS)
+3. to verify the identity of one or both parties in exchanging messages,
+    for example identity verification within [Transport Layer Security v1.3][tls] (TLS)
 
 OpenID Connect is widely used as an identity layer on top of the OAuth 2.0 protocol,
 see the [OAuth 2.0 Protocol][csoauth] Cheat Sheet.
 
 #### Integrity
 
-Integrity ensures that even authorized users have performed no accidental or malicious alternation of information.
+Integrity ensures that even authorized users have performed no accidental or malicious alteration of information.
 Cryptography can be used to prevent tampering by means of Message Authentication Codes (MACs) or digital signatures.
 
 The term 'message authenticity' refers to ensuring the integrity of information,
@@ -83,8 +82,9 @@ and, if asymmetric encryption is used, can authenticate the sender.
 
 #### Non-repudiation
 
-Non-repudiation of sender ensures that someone sending a message should not be able to deny later that they have sent it.
+Non-repudiation ensures that a sender cannot later deny having sent a message.
 Non-repudiation of receiver means that the receiver of a message should not be able to deny that they have received it.
+
 Cryptography can be used to provide non-repudiation by providing unforgeable messages or replies to messages.
 
 Non-repudiation is useful for financial, e-commerce, and contractual exchanges.
@@ -142,20 +142,22 @@ Symmetric ciphers come in two main types:
 1. Block ciphers, which operate on a block of characters (typically 8 or 16 octets) at a time.
     An example of a block cipher is AES
 2. Stream ciphers, which operate on a single bit (or occasionally a single byte) at a time.
-    Examples of a stream ciphers are RC4 (aka, ARC4) and Salsa20
+    Examples of stream ciphers are ChaCha20 (often paired with Poly1305) and Salsa20
 
 Note that all block ciphers can also operate in 'streaming mode' by selecting the appropriate cipher mode.
 
 #### Cipher Modes
 
-Block ciphers can function in different modes of operations known as "cipher modes".
+Block ciphers can function in different modes of operation known as "cipher modes".
 This cipher mode algorithmically describes how a cipher operates to repeatedly
 apply its encryption or decryption mechanism to a given cipher block.
 Cipher modes are important because they have an enormous impact on both the confidentiality
 and the message authenticity of the resulting ciphertext messages.
 
-Almost all cryptographic libraries support the four original DES cipher modes of ECB, CBC (Cipher Block Chaining)
+Almost all cryptographic libraries support the four original DES cipher modes of ECB (Electronic Code Book), CBC (Cipher Block Chaining)
 OFB (Output Feedback), and CFB (Cipher Feedback). Many also support CTR (Counter) mode.
+
+Note that the DES modes are insecure and aren't used today. Modern standards indicate the use of AEAD (Authenticated Encryption with Associated Data) modes that work on both block ciphers and stream ciphers, such as GCM (Galois Counter Mode), CCM (Counter with CBC-MAC), OCB (Offset Codebook Mode) and EAX (Encrypt-Then-Authenticate-and-Translate).
 
 #### Initialization vector
 
@@ -182,7 +184,7 @@ which is only used for the duration of the encrypted communication.
 This random session key is then encrypted using an asymmetric cipher and the recipient's private key.
 The plaintext data itself is encrypted with the session key.
 Then the entire bundle (encrypted session key and encrypted message) is all sent together.
-Both [TLS][tls] and S/MIME are common cryptosystems using hybrid cryptography.
+Both [TLS 1.3][tls] and S/MIME are common cryptosystems using hybrid cryptography today.
 
 #### Digital signature
 
@@ -248,6 +250,7 @@ These protocols prevent adversaries from learning the key or forcing their own k
   * [SAML Security][sscs]
   * [Secure Product Design][spdcs]
   * [User Privacy Protection][uppcs]
+  * [Cryptographic storage][cstorage]
 
 ----
 
@@ -266,3 +269,4 @@ then [submit an issue][issue0404] or [edit on GitHub][edit0404].
 [spdcs]: https://cheatsheetseries.owasp.org/cheatsheets/Secure_Product_Design_Cheat_Sheet
 [tls]: https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Security_Cheat_Sheet
 [uppcs]: https://cheatsheetseries.owasp.org/cheatsheets/User_Privacy_Protection_Cheat_Sheet
+[cstorage]: https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html

--- a/release/04-foundations/04-crypto-principles.md
+++ b/release/04-foundations/04-crypto-principles.md
@@ -30,7 +30,7 @@ of cryptography by the development team for the application or system.
 
 Although cryptography was initially restricted primarily to the military and the realm of academia,
 cryptography has become ubiquitous in securing software applications.
-Common every day uses of cryptography include cloud storage, passwords, SSL VPNs, smart cards, and end-to-end encrypted messaging apps.
+Common every day uses of cryptography include mobile phones, passwords, SSL VPNs, smart cards, and DVDs.
 Cryptography has permeated through everyday life, and is heavily used by many web applications.
 
 Cryptography is one of the more advanced topics of information security,
@@ -40,7 +40,7 @@ each with advantages and disadvantages that need to be thoroughly understood by 
 
 The proper and accurate implementation of cryptography is extremely critical to its efficacy.
 A small mistake in configuration or coding will result in removing most of the protection
-and rendering the crypto implementation useless.
+and rending the crypto implementation useless.
 
 A good understanding of crypto is required to be able to discern between solid products and snake oil.
 The inherent complexity of crypto makes it easy to fall for fantastic claims from vendors about their product.
@@ -50,8 +50,9 @@ If a vendor says "trust us, we have had experts look at this," chances are they 
 #### Confidentiality
 
 For the purposes of this section, confidentiality is defined as "no unauthorized disclosure of information".
-Cryptography addresses this via encryption of either the [data at rest][cstorage] or data in transit by
+Cryptography addresses this via encryption of either the data at rest or data in transit by
 protecting the information from all who do not hold the decryption key.
+Cryptographic hashes (secure, one way hashes) to prevent passwords from disclosure.
 
 #### Authentication
 
@@ -62,15 +63,15 @@ Cryptography is central to authentication:
 1. to protect the provided corroborating evidence (for example hashing of passwords for subsequent storage)
 2. in authentication protocols often use cryptography to either directly authenticate entities
     or to exchange credentials in a secure manner
-3. to verify the identity of one or both parties in exchanging messages,
-    for example identity verification within [Transport Layer Security v1.3][tls] (TLS)
+3. to verify the identity one or both parties in exchanging messages,
+    for example identity verification within [Transport Layer Security][tls] (TLS)
 
 OpenID Connect is widely used as an identity layer on top of the OAuth 2.0 protocol,
 see the [OAuth 2.0 Protocol][csoauth] Cheat Sheet.
 
 #### Integrity
 
-Integrity ensures that even authorized users have performed no accidental or malicious alteration of information.
+Integrity ensures that even authorized users have performed no accidental or malicious alternation of information.
 Cryptography can be used to prevent tampering by means of Message Authentication Codes (MACs) or digital signatures.
 
 The term 'message authenticity' refers to ensuring the integrity of information,
@@ -82,9 +83,8 @@ and, if asymmetric encryption is used, can authenticate the sender.
 
 #### Non-repudiation
 
-Non-repudiation ensures that a sender cannot later deny having sent a message.
+Non-repudiation of sender ensures that someone sending a message should not be able to deny later that they have sent it.
 Non-repudiation of receiver means that the receiver of a message should not be able to deny that they have received it.
-
 Cryptography can be used to provide non-repudiation by providing unforgeable messages or replies to messages.
 
 Non-repudiation is useful for financial, e-commerce, and contractual exchanges.
@@ -142,22 +142,20 @@ Symmetric ciphers come in two main types:
 1. Block ciphers, which operate on a block of characters (typically 8 or 16 octets) at a time.
     An example of a block cipher is AES
 2. Stream ciphers, which operate on a single bit (or occasionally a single byte) at a time.
-    Examples of stream ciphers are ChaCha20 (often paired with Poly1305) and Salsa20
+    Examples of a stream ciphers are RC4 (aka, ARC4) and Salsa20
 
 Note that all block ciphers can also operate in 'streaming mode' by selecting the appropriate cipher mode.
 
 #### Cipher Modes
 
-Block ciphers can function in different modes of operation known as "cipher modes".
+Block ciphers can function in different modes of operations known as "cipher modes".
 This cipher mode algorithmically describes how a cipher operates to repeatedly
 apply its encryption or decryption mechanism to a given cipher block.
 Cipher modes are important because they have an enormous impact on both the confidentiality
 and the message authenticity of the resulting ciphertext messages.
 
-Almost all cryptographic libraries support the four original DES cipher modes of ECB (Electronic Code Book), CBC (Cipher Block Chaining)
+Almost all cryptographic libraries support the four original DES cipher modes of ECB, CBC (Cipher Block Chaining)
 OFB (Output Feedback), and CFB (Cipher Feedback). Many also support CTR (Counter) mode.
-
-Note that the DES modes are insecure and aren't used today. Modern standards indicate the use of AEAD (Authenticated Encryption with Associated Data) modes that work on both block ciphers and stream ciphers, such as GCM (Galois Counter Mode), CCM (Counter with CBC-MAC), OCB (Offset Codebook Mode) and EAX (Encrypt-Then-Authenticate-and-Translate).
 
 #### Initialization vector
 
@@ -184,7 +182,7 @@ which is only used for the duration of the encrypted communication.
 This random session key is then encrypted using an asymmetric cipher and the recipient's private key.
 The plaintext data itself is encrypted with the session key.
 Then the entire bundle (encrypted session key and encrypted message) is all sent together.
-Both [TLS 1.3][tls] and S/MIME are common cryptosystems using hybrid cryptography today.
+Both [TLS][tls] and S/MIME are common cryptosystems using hybrid cryptography.
 
 #### Digital signature
 
@@ -250,7 +248,6 @@ These protocols prevent adversaries from learning the key or forcing their own k
   * [SAML Security][sscs]
   * [Secure Product Design][spdcs]
   * [User Privacy Protection][uppcs]
-  * [Cryptographic storage][cstorage]
 
 ----
 
@@ -269,4 +266,3 @@ then [submit an issue][issue0404] or [edit on GitHub][edit0404].
 [spdcs]: https://cheatsheetseries.owasp.org/cheatsheets/Secure_Product_Design_Cheat_Sheet
 [tls]: https://cheatsheetseries.owasp.org/cheatsheets/Transport_Layer_Security_Cheat_Sheet
 [uppcs]: https://cheatsheetseries.owasp.org/cheatsheets/User_Privacy_Protection_Cheat_Sheet
-[cstorage]: https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html


### PR DESCRIPTION
**Summary** :  
<!--
Provide a summary for the reviewers of this pull request, stating the section will help
Please provide enough information so that others can review your pull request
-->

This is a fix for issue #346 which called for a revision of principles of cryptography section to match today's standards. The major changes have been listen in the next section.

**Description for the changelog** :  
<!--
A short (one line) summary that describes the changes in this pull request
for inclusion in the change log
-->
I have made the following major changes.

1. Stream cipher examples, RC4 to ChaCha20 (because the RC4 algorithm has many vulnerabilities like biases in the key scheduling algorithm)
2. Updated with TLS version 1.3 being the recommended one
3. Updated with note on DES not being a standard, and added AEAD schemes.
4. Corrected spelling errors and other grammatical issues
5. Added link to the cryptographic storage cheat sheet.
 
**Other info** :  
<!--
Add here any other information that may be of help to the reviewer
If this closes an existing issue then add "closes #xxxx", where xxxx is the issue number
-->
closes #346 
