### PR TITLE
Clarify wording of password sending recommendation

### DIFF
--- a/draft/06-design/02-web-app-checklist/06-digital-identity.md
+++ b/draft/06-design/02-web-app-checklist/06-digital-identity.md
@@ -47,7 +47,7 @@ and use the list below as suggestions for a checklist that has been tailored for
 1. Utilize authentication for connections to external systems that involve sensitive information or functions
 1. Authentication credentials for accessing services external to the application should be stored in a secure store
 1. Use only HTTP POST requests to transmit authentication credentials
-1. Only send non-temporary passwords over an encrypted connection or as encrypted data
+1. Always send non-temporary passwords over an encrypted connection or as encrypted data
 1. Enforce password complexity and length requirements established by policy or regulation
 1. Enforce account disabling after an established number of invalid login attempts
 1. Password reset and changing operations require the same level of controls as account creation and authentication


### PR DESCRIPTION
**Summary** :  
<!--
Provide a summary for the reviewers of this pull request, stating the section will help
Please provide enough information so that others can review your pull request
-->
The recommendation for sending passwords can be read two ways, either as "Always send non-temporary passwords encrypted" or as "Don't send temporary passwords encrypted". This commit clarifies that the former interpretation is the intended one.

**Description for the changelog** :  
<!--
A short (one line) summary that describes the changes in this pull request
for inclusion in the change log
-->
Clarify wording of password sending recommendation

**Declaration**:

- [X] content meets the [license](../license.txt) for this project
- [x] AI has not been used, or is declared, in this pull request

**Other info** :  
<!-- Add here any other information that may be of help to the reviewer -->

Thanks for submitting a pull request!

Please make sure you follow our [Code of Conduct](../code_of_conduct.md)
and our [contributing guidelines](../contributing.md)

Automated tests are run to check links, markdown and spelling

The pull request must pass these tests before it can be merged
